### PR TITLE
Add InteliJ to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ xcuserdata
 /newrelic_agent.log
 /CodeSigning.xcconfig
 /.vscode
+
+## AppCode specific
+.idea/


### PR DESCRIPTION
InteliJ editors automatically generate a `.idea` folder. This should not be commited.