### PR TITLE
Use Xcode 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,12 +3,16 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build and upload SideStore
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Setup Xcode 14
+        uses: maxim-lobanov/setup-xcode@v1.4.1
+        with:
+          xcode-version: '14.0-beta'
       - name: Build SideStore
         run: |
           rm -rf ~/Library/Developer/Xcode/DerivedData/


### PR DESCRIPTION
New iOS 16 features require Xcode 14
Xcode 14 is only available on macOS 12 runners

Signed-off-by: JJTech <jjtech@jjtech.dev>