### PR TITLE
Change settings altstore names to SideStore

### DIFF
--- a/AltStore/Info.plist
+++ b/AltStore/Info.plist
@@ -90,7 +90,7 @@
 		<string>_altserver._tcp</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>AltStore uses the local network to find and communicate with AltServer.</string>
+	<string>SideStore uses the local network to find and communicate with SideServer.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>RefreshAllIntent</string>

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -100,11 +100,11 @@ class SettingsViewController: UITableViewController
         
         if let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         {
-            self.versionLabel.text = NSLocalizedString(String(format: "AltStore %@", version), comment: "AltStore Version")
+            self.versionLabel.text = NSLocalizedString(String(format: "SideStore %@", version), comment: "SideStore Version")
         }
         else
         {
-            self.versionLabel.text = NSLocalizedString("AltStore", comment: "")
+            self.versionLabel.text = NSLocalizedString("SideStore", comment: "")
         }
         
         self.tableView.contentInset.bottom = 20
@@ -168,7 +168,7 @@ private extension SettingsViewController
             }
             else
             {
-                settingsHeaderFooterView.secondaryLabel.text = NSLocalizedString("Sign in with your Apple ID to download apps from AltStore.", comment: "")
+                settingsHeaderFooterView.secondaryLabel.text = NSLocalizedString("Sign in with your Apple ID to download apps from SideStore.", comment: "")
             }
             
         case .patreon:
@@ -178,7 +178,7 @@ private extension SettingsViewController
             }
             else
             {
-                settingsHeaderFooterView.secondaryLabel.text = NSLocalizedString("Receive access to beta versions of AltStore, Delta, and more by becoming a patron.", comment: "")
+                settingsHeaderFooterView.secondaryLabel.text = NSLocalizedString("Don't Touch this button above =) ", comment: "")
             }
             
         case .account:
@@ -195,7 +195,7 @@ private extension SettingsViewController
             }
             else
             {
-                settingsHeaderFooterView.secondaryLabel.text = NSLocalizedString("Enable Background Refresh to automatically refresh apps in the background when connected to the same Wi-Fi as AltServer.", comment: "")
+                settingsHeaderFooterView.secondaryLabel.text = NSLocalizedString("Enable Background Refresh to automatically refresh apps in the background when connected to the same Wi-Fi as SideServer.", comment: "")
             }
             
         case .instructions:
@@ -468,7 +468,7 @@ extension SettingsViewController
             let row = CreditsRow.allCases[indexPath.row]
             switch row
             {
-            case .developer: self.openTwitter(username: "rileytestut")
+            case .developer: self.openTwitter(username: "SideTeam")
             case .operations: self.openTwitter(username: "shanegillio")
             case .designer: self.openTwitter(username: "1carolinemoore")
             case .softwareLicenses: break

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -176,10 +176,6 @@ private extension SettingsViewController
             {
                 settingsHeaderFooterView.primaryLabel.text = NSLocalizedString("PATREON", comment: "")
             }
-            else
-            {
-                settingsHeaderFooterView.secondaryLabel.text = NSLocalizedString("Don't Touch this button above =) ", comment: "")
-            }
             
         case .account:
             settingsHeaderFooterView.primaryLabel.text = NSLocalizedString("ACCOUNT", comment: "")

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -176,7 +176,11 @@ private extension SettingsViewController
             {
                 settingsHeaderFooterView.primaryLabel.text = NSLocalizedString("PATREON", comment: "")
             }
-            
+            else
+            {
+                settingsHeaderFooterView.secondaryLabel.text = NSLocalizedString("Receive access to beta versions of AltStore, Delta, and more by becoming a patron.", comment: "")
+            }
+
         case .account:
             settingsHeaderFooterView.primaryLabel.text = NSLocalizedString("ACCOUNT", comment: "")
             


### PR DESCRIPTION
This changes a few settings descriptions to say sidestore instead of AltStore. This also includes pop up for local lan traffic

![2DF6C4CD-A69C-4CC1-90FF-F6B1E2B5FC9C](https://user-images.githubusercontent.com/64176728/187750695-52cd35aa-f029-41c4-87b8-35ca787687c7.png)
![94FF8875-DF57-4905-AD7F-14B985A5BA0D](https://user-images.githubusercontent.com/64176728/187750703-76be86df-da71-451e-9df0-e685ed5c4b6e.png)
![DF85AFA5-0AC2-4C30-9FF1-AA10A0D90F97](https://user-images.githubusercontent.com/64176728/187750715-9e119c1d-4d15-47e4-a9d6-d0b73fce1cdb.png)
