### PR TITLE
Bump minimum Xcode version to Xcode 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,7 @@ jobs:
         include:
           - os: 'macos-12'
             version: '14.0-beta'
-          - os: 'macos-12'
-            version: '13.4.1'
-          - os: 'macos-11'
-            version: '13.2.1'
-        
+    
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The goal of this project is to allow easy and a mostly computerless experience t
 
 
 ## Requirements
-- Xcode 11
+- Xcode 14
 - iOS 12.2+ (SideStore)
 - macOS 10.14.4+ (TBD)
 - Swift 5+


### PR DESCRIPTION
It doesn't even build on Xcode 13, there is no point pretending it does.