### PR TITLE
Change Xcode version to 14.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - os: 'macos-12'
-            version: '14.0-beta'
+            version: '14.0.0'
     
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This fixes actions to use stable 14.0.0 as GitHub wouldn’t allow 14.0-beta no longer.
Signed-off-by: Spidy123222