### PR TITLE
Change version back to 1.5.1b 

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
       "name": "Altstore",
       "bundleIdentifier": "com.SideStore.AltStore",
       "developerName": "Side Team",
-      "version": "1.5.2b",
+      "version": "1.5.1b",
       "versionDate": "2022-07-14T12:00:00-05:00",
       "versionDescription": "Welcome to the pacer test.",
       "downloadURL": "https://cdn.altstore.io/file/altstore/apps/altstore/1_5_1.ipa",


### PR DESCRIPTION
This changes the app version back to 1.5.1b. This is temporary while migrating apps.json back to its own repo as joematt set up the domain there.