### PR TITLE
Add pojavlauncher to trusted sources

### DIFF
--- a/AltStore/Operations/FetchTrustedSourcesOperation.swift
+++ b/AltStore/Operations/FetchTrustedSourcesOperation.swift
@@ -11,9 +11,9 @@ import Foundation
 private extension URL
 {
     #if STAGING
-    static let trustedSources = URL(string: "https://raw.githubusercontent.com/SideStore/SideStore/develop/trustedapps.json")!
+    static let trustedSources = URL(string: "https://raw.githubusercontent.com/Spidy123222/SideStore/Add-trusted-source/trustedapps.json")!
     #else
-    static let trustedSources = URL(string: "https://raw.githubusercontent.com/SideStore/SideStore/develop/trustedapps.json")!
+    static let trustedSources = URL(string: "https://raw.githubusercontent.com/Spidy123222/SideStore/Add-trusted-source/trustedapps.json")!
     #endif
 }
 

--- a/AltStore/Operations/FetchTrustedSourcesOperation.swift
+++ b/AltStore/Operations/FetchTrustedSourcesOperation.swift
@@ -11,9 +11,9 @@ import Foundation
 private extension URL
 {
     #if STAGING
-    static let trustedSources = URL(string: "https://raw.githubusercontent.com/Spidy123222/SideStore/Add-trusted-source/trustedapps.json")!
+    static let trustedSources = URL(string: "https://raw.githubusercontent.com/SideStore/SideStore/develop/trustedapps.json")!
     #else
-    static let trustedSources = URL(string: "https://raw.githubusercontent.com/Spidy123222/SideStore/Add-trusted-source/trustedapps.json")!
+    static let trustedSources = URL(string: "https://raw.githubusercontent.com/SideStore/SideStore/develop/trustedapps.json")!
     #endif
 }
 

--- a/trustedapps.json
+++ b/trustedapps.json
@@ -19,6 +19,9 @@
     {
       "identifier": "org.provenance-emu.provenance",
       "sourceURL": "https://provenance-emu.com/apps.json"
-    }
+    },
+    {
+      "identifier": "dev.crystall1ne.repos.PojavLauncher"
+      "sourceURL" "https://alt.crystall1ne.software/"
   ]
 }

--- a/trustedapps.json
+++ b/trustedapps.json
@@ -23,5 +23,6 @@
     {
       "identifier": "dev.crystall1ne.repos.PojavLauncher"
       "sourceURL" "https://alt.crystall1ne.software/"
+    }
   ]
 }

--- a/trustedapps.json
+++ b/trustedapps.json
@@ -22,7 +22,7 @@
     },
     {
       "identifier": "dev.crystall1ne.repos.PojavLauncher"
-      "sourceURL" "https://alt.crystall1ne.software/"
+      "sourceURL": "https://alt.crystall1ne.software/"
     }
   ]
 }

--- a/trustedapps.json
+++ b/trustedapps.json
@@ -21,7 +21,7 @@
       "sourceURL": "https://provenance-emu.com/apps.json"
     },
     {
-      "identifier": "dev.crystall1ne.repos.PojavLauncher"
+      "identifier": "dev.crystall1ne.repos.PojavLauncher",
       "sourceURL": "https://alt.crystall1ne.software/"
     }
   ]


### PR DESCRIPTION
This adds the Pojavlauncher AltStore source as a trusted source in sidestore. I have tested this to work and if you want to try it out you can use my ipa that uses my forks trusted source.

[SideStore 24.zip](https://github.com/SideStore/SideStore/files/9936073/SideStore.24.zip)
