### PR TITLE
[#102][#101] Loading view error handling, Load pairingfile from docs, bundle, plist

### DIFF
--- a/AltStore.xcodeproj/project.pbxproj
+++ b/AltStore.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		B3146ED2284F581E00BBC3FD /* Roxas.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3146ECD284F580500BBC3FD /* Roxas.framework */; };
 		B3146ED3284F581E00BBC3FD /* Roxas.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B3146ECD284F580500BBC3FD /* Roxas.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B39575F5284F29E20080B4FF /* Roxas.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B39575F4284F29E20080B4FF /* Roxas.framework */; };
+		B39F16132918D7C5002E9404 /* Consts.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F16122918D7C5002E9404 /* Consts.swift */; };
+		B39F16152918D7DA002E9404 /* Consts+Proxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39F16142918D7DA002E9404 /* Consts+Proxy.swift */; };
 		B3C395F1284F2DE700DA9E2F /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = B3C395F0284F2DE700DA9E2F /* KeychainAccess */; };
 		B3C395F4284F35DD00DA9E2F /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = B3C395F3284F35DD00DA9E2F /* Nuke */; };
 		B3C395F7284F362400DA9E2F /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = B3C395F6284F362400DA9E2F /* AppCenterAnalytics */; };
@@ -561,6 +563,8 @@
 		19B9B7442845E6DF0076EF69 /* SelectTeamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectTeamViewController.swift; sourceTree = "<group>"; };
 		B3146EC6284F580500BBC3FD /* Roxas.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Roxas.xcodeproj; path = Dependencies/Roxas/Roxas.xcodeproj; sourceTree = "<group>"; };
 		B39575F4284F29E20080B4FF /* Roxas.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Roxas.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B39F16122918D7C5002E9404 /* Consts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Consts.swift; sourceTree = "<group>"; };
+		B39F16142918D7DA002E9404 /* Consts+Proxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Consts+Proxy.swift"; sourceTree = "<group>"; };
 		B3C39606284F4C8400DA9E2F /* CodeSigning.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = CodeSigning.xcconfig; sourceTree = "<group>"; };
 		B3C39607284F4C8400DA9E2F /* Build.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Build.xcconfig; sourceTree = "<group>"; };
 		B3C39608284F4C8400DA9E2F /* CodeSigning.xcconfig.sample */ = {isa = PBXFileReference; lastKnownFileType = text; path = CodeSigning.xcconfig.sample; sourceTree = "<group>"; };
@@ -1077,6 +1081,15 @@
 				B3146ED1284F580500BBC3FD /* RoxasTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		B39F16112918D7B5002E9404 /* Consts */ = {
+			isa = PBXGroup;
+			children = (
+				B39F16122918D7C5002E9404 /* Consts.swift */,
+				B39F16142918D7DA002E9404 /* Consts+Proxy.swift */,
+			);
+			path = Consts;
 			sourceTree = "<group>";
 		};
 		BF055B4A233B528B0086DEA9 /* Extensions */ = {
@@ -1679,6 +1692,7 @@
 		BFD2476C2284B9A500981D42 /* AltStore */ = {
 			isa = PBXGroup;
 			children = (
+				B39F16112918D7B5002E9404 /* Consts */,
 				BF219A7E22CAC431007676A6 /* AltStore.entitlements */,
 				BFD2476D2284B9A500981D42 /* AppDelegate.swift */,
 				BF4B78FD24B3D1DB008AB4AC /* SceneDelegate.swift */,
@@ -2726,6 +2740,7 @@
 				BF3D64B022E8D4B800E9056B /* AppContentViewControllerCells.swift in Sources */,
 				BFC57A6E2416FC5D00EB891E /* InstalledAppsCollectionHeaderView.swift in Sources */,
 				BF88F97224F8727D00BB75DF /* AppManagerErrors.swift in Sources */,
+				B39F16152918D7DA002E9404 /* Consts+Proxy.swift in Sources */,
 				BF6C8FAE2429597900125131 /* BannerCollectionViewCell.swift in Sources */,
 				BF6F439223644C6E00A0B879 /* RefreshAltStoreViewController.swift in Sources */,
 				BFE60742231B07E6002B0E8E /* SettingsHeaderFooterView.swift in Sources */,
@@ -2736,6 +2751,7 @@
 				BF41B808233433C100C593A3 /* LoadingState.swift in Sources */,
 				BFF0B69A2322D7D0007A79E1 /* UIScreen+CompactHeight.swift in Sources */,
 				D5F2F6A92720B7C20081CCF5 /* PatchViewController.swift in Sources */,
+				B39F16132918D7C5002E9404 /* Consts.swift in Sources */,
 				BF8F69C222E659F700049BA1 /* AppContentViewController.swift in Sources */,
 				BF08858522DE7EC800DE9F1E /* UpdateCollectionViewCell.swift in Sources */,
 				BFB39B5C252BC10E00D1BE50 /* Managed.swift in Sources */,

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -103,7 +103,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillEnterForeground(_ application: UIApplication)
     {
         AppManager.shared.update()
-        start_em_proxy(bind_addr: "127.0.0.1:51820")
+        start_em_proxy(bind_addr: Consts.Proxy.serverURL)
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool

--- a/AltStore/Consts/Consts+Proxy.swift
+++ b/AltStore/Consts/Consts+Proxy.swift
@@ -1,0 +1,17 @@
+//
+//  Proxy.swift
+//  SideStore
+//
+//  Created by Joseph Mattiello on 11/7/22.
+//  Copyright © 2022 Riley Testut. All rights reserved.
+//
+
+import Foundation
+
+public extension Consts {
+   enum Proxy {
+        static let address = "127.0.0.1"
+        static let port = "51820"
+        static let serverURL = "\(address):\(port)"
+    }
+}

--- a/AltStore/Consts/Consts.swift
+++ b/AltStore/Consts/Consts.swift
@@ -1,0 +1,13 @@
+//
+//  Consts.swift
+//  SideStore
+//
+//  Created by Joseph Mattiello on 11/7/22.
+//  Copyright © 2022 Riley Testut. All rights reserved.
+//
+
+import Foundation
+
+public enum Consts {
+
+}

--- a/AltStore/LaunchViewController.swift
+++ b/AltStore/LaunchViewController.swift
@@ -37,16 +37,52 @@ class LaunchViewController: RSTLaunchViewController
     
     override func viewDidLoad()
     {
+        defer {
+            // Create destinationViewController now so view controllers can register for receiving Notifications.
+            self.destinationViewController = self.storyboard!.instantiateViewController(withIdentifier: "tabBarController") as! TabBarController
+        }
         super.viewDidLoad()
-        start_em_proxy(bind_addr: "127.0.0.1:51820")
+        start_em_proxy(bind_addr: Consts.Proxy.serverURL)
         
-        let pf = Bundle.main.object(forInfoDictionaryKey: "ALTPairingFile") as? String
+        guard let pf = fetchPairingFile() else {
+            displayError("ALTPairingFile not found.")
+            return
+        }
         set_usbmuxd_socket()
-        start_minimuxer(pairing_file: pf.unsafelyUnwrapped)
+        start_minimuxer(pairing_file: pf)
         auto_mount_dev_image()
+    }
+    
+    func fetchPairingFile() -> String? {
+        let filename = "ALTPairingFile.plist"
+        let fm = FileManager.default
+        let documentsPath = fm.documentsDirectory.appendingPathComponent("/\(filename)")
+        if fm.fileExists(atPath: documentsPath.path), let contents = try? String(contentsOf: documentsPath), !contents.isEmpty {
+            return contents
+        } else if
+            let appResourcePath = Bundle.main.url(forResource: "ALTPairingFile", withExtension: "plist"),
+            fm.fileExists(atPath: appResourcePath.path),
+            let contents = try? String(contentsOf: appResourcePath), !contents.isEmpty  {
+            return contents
+        } else if let plistString = Bundle.main.object(forInfoDictionaryKey: "ALTPairingFile") as? String, !plistString.isEmpty, !plistString.contains("insert pairing file here"){
+            return plistString
+        } else {
+            return nil
+        }
+    }
+    
+    func displayError(_ msg: String) {
+        let label = UILabel()
+        label.text = msg
+        label.textColor = .refreshRed
+        label.sizeToFit()
         
-        // Create destinationViewController now so view controllers can register for receiving Notifications.
-        self.destinationViewController = self.storyboard!.instantiateViewController(withIdentifier: "tabBarController") as! TabBarController
+        self.view.addSubview(label)
+        
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
     }
 }
 

--- a/AltStore/LaunchViewController.swift
+++ b/AltStore/LaunchViewController.swift
@@ -54,17 +54,22 @@ class LaunchViewController: RSTLaunchViewController
     }
     
     func fetchPairingFile() -> String? {
-        let filename = "ALTPairingFile.plist"
+        let filename = "ALTPairingFile.mobiledevicepairing"
         let fm = FileManager.default
         let documentsPath = fm.documentsDirectory.appendingPathComponent("/\(filename)")
         if fm.fileExists(atPath: documentsPath.path), let contents = try? String(contentsOf: documentsPath), !contents.isEmpty {
+            print("Loaded ALTPairingFile from \(documentsPath.path)")
             return contents
         } else if
-            let appResourcePath = Bundle.main.url(forResource: "ALTPairingFile", withExtension: "plist"),
+            let appResourcePath = Bundle.main.url(forResource: "ALTPairingFile", withExtension: "mobiledevicepairing"),
             fm.fileExists(atPath: appResourcePath.path),
-            let contents = try? String(contentsOf: appResourcePath), !contents.isEmpty  {
+            let data = fm.contents(atPath: appResourcePath.path),
+            let contents = String(data: data, encoding: .utf8),
+            !contents.isEmpty  {
+            print("Loaded ALTPairingFile from \(appResourcePath.path)")
             return contents
         } else if let plistString = Bundle.main.object(forInfoDictionaryKey: "ALTPairingFile") as? String, !plistString.isEmpty, !plistString.contains("insert pairing file here"){
+            print("Loaded ALTPairingFile from Info.plist")
             return plistString
         } else {
             return nil

--- a/AltStore/Operations/BackgroundRefreshAppsOperation.swift
+++ b/AltStore/Operations/BackgroundRefreshAppsOperation.swift
@@ -96,7 +96,7 @@ class BackgroundRefreshAppsOperation: ResultOperation<[String: Result<InstalledA
             self.finish(.failure(RefreshError.noInstalledApps))
             return
         }
-        start_em_proxy(bind_addr: "127.0.0.1:51820")
+        start_em_proxy(bind_addr: Consts.Proxy.serverURL)
         
         self.managedObjectContext.perform {
             print("Apps to refresh:", self.installedApps.map(\.bundleIdentifier))

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -40,7 +40,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
         guard DatabaseManager.shared.isStarted else { return }
         
         AppManager.shared.update()
-        start_em_proxy(bind_addr: "127.0.0.1:51820")
+        start_em_proxy(bind_addr: Consts.Proxy.serverURL)
         
         PatreonAPI.shared.refreshPatreonAccount()
     }


### PR DESCRIPTION
Tries 
`Documents/ALTPairingFile.mobiledevicepairing`
then app bundle resources `ALTPairingFile.mobiledevicepairing`, 
finally Info.plist with non default value.

It also checks that the file isn't empty. Should I test if it's a valid plist?

I used `.mobiledevicepairing` instead of `.plist` since XCode wants to compile plists. You can manually move to the Copy phase, but it's easier just to use the other extensions.

Also added an error label if no file found.

Signed-off-by: Joseph Mattello <mail@joemattiello.com>
