### PR TITLE
Change version on to reflect being pre-release

### DIFF
--- a/AltStore.xcodeproj/project.pbxproj
+++ b/AltStore.xcodeproj/project.pbxproj
@@ -3115,7 +3115,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
-				MARKETING_VERSION = 1.0.0b;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rileytestut.AltServer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -3165,7 +3165,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
-				MARKETING_VERSION = 1.0.0b;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.rileytestut.AltServer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -3648,7 +3648,7 @@
 					"$(PROJECT_DIR)/Dependencies/minimuxer/target/aarch64-apple-ios/debug",
 					"$(PROJECT_DIR)/Dependencies/minimuxer/target/aarch64-apple-ios/release",
 				);
-				MARKETING_VERSION = 1.0.0b;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -3685,7 +3685,7 @@
 					"$(PROJECT_DIR)/Dependencies/minimuxer/target/aarch64-apple-ios/debug",
 					"$(PROJECT_DIR)/Dependencies/minimuxer/target/aarch64-apple-ios/release",
 				);
-				MARKETING_VERSION = 1.0.0b;
+				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AltStoreCore/Model/Source.swift
+++ b/AltStoreCore/Model/Source.swift
@@ -19,17 +19,17 @@ public extension Source
     #if STAGING
     
     #if ALPHA
-    static let altStoreSourceURL = URL(string: "https://raw.githubusercontent.com/SideStore/SideStore/develop/app.json")!
+    static let altStoreSourceURL = URL(string: "https://apps.sidestore.io/")!
     #else
-    static let altStoreSourceURL = URL(string: "https://raw.githubusercontent.com/SideStore/SideStore/develop/app.json")!
+    static let altStoreSourceURL = URL(string: "https://apps.sidestore.io/")!
     #endif
     
     #else
     
     #if ALPHA
-    static let altStoreSourceURL = URL(string: "https://raw.githubusercontent.com/SideStore/SideStore/develop/app.json")!
+    static let altStoreSourceURL = URL(string: "https://apps.sidestore.io/")!
     #else
-    static let altStoreSourceURL = URL(string: "https://raw.githubusercontent.com/SideStore/SideStore/develop/app.json")!
+    static let altStoreSourceURL = URL(string: "https://apps.sidestore.io/")!
     #endif
     
     #endif

--- a/Build.xcconfig
+++ b/Build.xcconfig
@@ -1,8 +1,8 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
-MARKETING_VERSION = 1.0.0
-CURRENT_PROJECT_VERSION = 3000
+MARKETING_VERSION = 0.1.0
+CURRENT_PROJECT_VERSION = 3001
 
 // Vars to be overwritten by `CodeSigning.xcconfig` if exists
 DEVELOPMENT_TEAM = S32Z3HMYVQ

--- a/app.json
+++ b/app.json
@@ -6,11 +6,11 @@
     {
       "name": "SideStore",
       "bundleIdentifier": "com.SideStore.SideStore",
-      "developerName": "Side Team",
+      "developerName": "SideStore Team",
       "version": "0.1.0",
       "versionDate": "2022-010-15T12:00:00-05:00",
-      "versionDescription": "Welcome to the pacer test.",
-      "downloadURL": "https://cdn.altstore.io/file/altstore/apps/altstore/1_5_1.ipa",
+      "versionDescription": "Welcome to the next generation of sideloading!",
+      "downloadURL": "https://nythepegasus.com/SideStore.ipa",
       "localizedDescription": "SideStore is an alternative app store for non-jailbroken devices. \n\nSideStore allows you to sideload other .ipa files and apps from the Files app or via the SideStore Library",
       "iconURL": "https://raw.githubusercontent.com/SideStore/apps.json/main/105070799.jpeg",
       "tintColor": "8043FF",
@@ -66,7 +66,7 @@
     {
       "title": "New to SideStore?",
       "identifier": "updated-faq",
-      "caption": "Check out our updated guide to learn how to sideload apps!",
+      "caption": "Good luck!",
       "tintColor": "8043FF",
       "url": "https://faq.sidestore.io",
       "date": "2050-07-28",

--- a/app.json
+++ b/app.json
@@ -1,14 +1,14 @@
 {
   "name": "SideStore Offical",
   "identifier": "com.SideStore.SideStore",
-  "sourceURL": "https://raw.githubusercontent.com/Spidy123222/apps.json/main/app.json",
+  "sourceURL": "https://apps.sidestore.io/",
   "apps": [
     {
       "name": "SideStore",
       "bundleIdentifier": "com.SideStore.SideStore",
       "developerName": "Side Team",
-      "version": "1.0.0",
-      "versionDate": "2022-07-14T12:00:00-05:00",
+      "version": "0.1.0",
+      "versionDate": "2022-010-15T12:00:00-05:00",
       "versionDescription": "Welcome to the pacer test.",
       "downloadURL": "https://cdn.altstore.io/file/altstore/apps/altstore/1_5_1.ipa",
       "localizedDescription": "SideStore is an alternative app store for non-jailbroken devices. \n\nSideStore allows you to sideload other .ipa files and apps from the Files app or via the SideStore Library",


### PR DESCRIPTION
This changes version to be 0.1.0 instead and also adds apps.sidestore.io default source link.