### PR TITLE
Fix Refreshing sidestore and staging error.

### DIFF
--- a/AltStore.xcconfig
+++ b/AltStore.xcconfig
@@ -1,3 +1,3 @@
 #include "Build.xcconfig"
 
-PRODUCT_BUNDLE_IDENTIFIER = $(ORG_PREFIX).AltStore
+PRODUCT_BUNDLE_IDENTIFIER = $(ORG_PREFIX).SideStore

--- a/AltStore/Operations/FetchProvisioningProfilesOperation.swift
+++ b/AltStore/Operations/FetchProvisioningProfilesOperation.swift
@@ -136,7 +136,7 @@ extension FetchProvisioningProfilesOperation
                 if app.isAltStoreApp
                 {
                     // Use legacy bundle ID format for AltStore.
-                    preferredBundleID = "com.\(team.identifier).\(app.bundleIdentifier)"
+                    preferredBundleID = teamsMatch ? installedApp.resignedBundleIdentifier : nil
                 }
                 else
                 {
@@ -181,7 +181,7 @@ extension FetchProvisioningProfilesOperation
                 if app.isAltStoreApp
                 {
                     // Use legacy bundle ID format for AltStore (and its extensions).
-                    updatedParentBundleID = "com.\(team.identifier).\(parentBundleID)"
+                    updatedParentBundleID = parentBundleID + "." + team.identifier // Append just team identifier to make it harder to track.
                 }
                 else
                 {

--- a/Build.xcconfig
+++ b/Build.xcconfig
@@ -6,7 +6,7 @@ CURRENT_PROJECT_VERSION = 3001
 
 // Vars to be overwritten by `CodeSigning.xcconfig` if exists
 DEVELOPMENT_TEAM = S32Z3HMYVQ
-ORG_IDENTIFIER = com.joemattiello
+ORG_IDENTIFIER = com.SideStore
 
 // Codesigning settings defined optionally, see `CodeSigning.xcconfig.example`
 #include? "CodeSigning.xcconfig"
@@ -16,8 +16,8 @@ ORG_PREFIX = $(ORG_IDENTIFIER)
 PRODUCT_NAME = SideStore
 //PRODUCT_NAME[configuration=Debug] = Prov Debug
 
-PRODUCT_BUNDLE_IDENTIFIER   = $(ORG_PREFIX).$(PROJECT_NAME)
+PRODUCT_BUNDLE_IDENTIFIER   = $(ORG_PREFIX).SideStore
 //PRODUCT_BUNDLE_IDENTIFIER[configuration=Debug] = $(ORG_PREFIX).$(PROJECT_NAME:lower)-debug
 
-APP_GROUP_IDENTIFIER        = $(ORG_PREFIX).$(PROJECT_NAME)
+APP_GROUP_IDENTIFIER        = $(ORG_PREFIX).SideStore
 ICLOUD_CONTAINER_IDENTIFIER = iCloud.$(ORG_PREFIX).$(PROJECT_NAME)

--- a/Shared/Extensions/Bundle+AltStore.swift
+++ b/Shared/Extensions/Bundle+AltStore.swift
@@ -53,7 +53,7 @@ public extension Bundle
 
 public extension Bundle
 {
-    static var baseAltStoreAppGroupID = "group.com.rileytestut.AltStore"
+    static var baseAltStoreAppGroupID = "group.com.SideStore.SideStore"
     
     var appGroups: [String] {
         return self.infoDictionary?[Bundle.Info.appGroups] as? [String] ?? []


### PR DESCRIPTION
This fixes refreshing side store app from making a second app because it using legacy AltStore formatted bundleid so I did a simple fix. Unable to stage sidestore during refresh was also fixed by forcing the org id to be group.com.SideStore.SideStore and making sure xconfig applies .SideStore at the end of bundleid and groupID. I have tested this using https://github.com/SideStore/SideStore/pull/120 and it has worked. If you want to do a similar test I Have an action on my GitHub fork here https://github.com/Spidy123222/SideStore/actions/runs/3492216908