### PR TITLE
Add SideKit integration

### DIFF
--- a/AltStore/Info.plist
+++ b/AltStore/Info.plist
@@ -58,7 +58,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>altstore</string>
-        <string>sidestore</string>
+                                <string>sidestore</string>
 			</array>
 		</dict>
 		<dict>

--- a/AltStore/Info.plist
+++ b/AltStore/Info.plist
@@ -68,6 +68,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>altstore-com.rileytestut.AltStore</string>
+                                <string>sidestore-com.SideStore.SideStore</string>
 			</array>
 		</dict>
 	</array>

--- a/AltStore/Info.plist
+++ b/AltStore/Info.plist
@@ -58,6 +58,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>altstore</string>
+        <string>sidestore</string>
 			</array>
 		</dict>
 		<dict>
@@ -68,7 +69,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>altstore-com.rileytestut.AltStore</string>
-                                <string>sidestore-com.SideStore.SideStore</string>
+        <string>sidestore-com.SideStore.SideStore</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
This is a draft to add jit activator methods for sidestore for external apps.

How it's supposed to work is having 69.69.0.1 which is jitstreamer server to have sidestore act as it which this would bring up instant backwards compatibility while apps intergrate sidekit and it will be the fast path since it's more seamless compared to using url scheme which will open app which is useful to activate if sidestore is not awake. 1234567890 is a fake process ID for examples below.

Jitstreamer url http://69.69.0.1/attach/1234567890

What a url scheme could look like 

sidestore://debugpid?url=1234567890