### PR TITLE
Better anisette settings

### DIFF
--- a/AltStore/Settings.bundle/Root.plist
+++ b/AltStore/Settings.bundle/Root.plist
@@ -10,13 +10,59 @@
 	<array>
 		<dict>
 			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
+			<string>Anisette Server</string>
+			<key>Key</key>
+			<string>customAnisetteURL</string>
+			<key>DefaultValue</key>
+			<string>http://191.101.206.188:6969</string>
+			<key>Titles</key>
+			<array>
+				<string>Macley (US)</string>
+				<string>Macley (DE)</string>
+				<string>DrPudding</string>
+				<string>jkcoxson (AltServer)</string>
+				<string>jkcoxson (Provision)</string>
+				<string>Sideloadly</string>
+				<string>Nick</string>
+				<string>Jawshoeadan</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>http://us1.sternserv.tech</string>
+				<string>http://de1.sternserv.tech</string>
+				<string>https://sign.rheaa.xyz</string>
+				<string>http://jkcoxson.com:2095</string>
+				<string>http://jkcoxson.com:2052</string>
+				<string>https://sideloadly.io/anisette/irGb3Quww8zrhgqnzmrx</string>
+				<string>http://45.33.29.114</string>
+				<string>https://anisette.jawshoeadan.me</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>Danger Zone</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Use preferred servers</string>
+			<key>Key</key>
+			<string>textServer</string>
+			<key>DefaultValue</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSTextFieldSpecifier</string>
 			<key>Title</key>
 			<string>Anisette URL</string>
 			<key>Key</key>
-			<string>customAnisetteURL</string>
-			<key>IsSecure</key>
-			<string>Alphabet</string>
+			<string>textInputAnisetteURL</string>
 			<key>AutocapitalizationType</key>
 			<string>None</string>
 			<key>AutocorrectionType</key>

--- a/AltStore/Settings.bundle/Root.plist
+++ b/AltStore/Settings.bundle/Root.plist
@@ -27,6 +27,7 @@
 				<string>Sideloadly</string>
 				<string>Nick</string>
 				<string>Jawshoeadan</string>
+				<string>crystall1nedev</string>
 			</array>
 			<key>Values</key>
 			<array>
@@ -38,6 +39,7 @@
 				<string>https://sideloadly.io/anisette/irGb3Quww8zrhgqnzmrx</string>
 				<string>http://45.33.29.114</string>
 				<string>https://anisette.jawshoeadan.me</string>
+				<string>https://anisette.crystall1ne.software/</string>
 			</array>
 		</dict>
 		<dict>

--- a/AltStore/Settings.bundle/Root.plist
+++ b/AltStore/Settings.bundle/Root.plist
@@ -45,6 +45,8 @@
 			<string>PSGroupSpecifier</string>
 			<key>Title</key>
 			<string>Danger Zone</string>
+			<key>FooterText</key>
+			<string>If you disable the toggle then app will use the server you input into the &quot;Anisette URL&quot; box rather than one selected from the above selector.</string>
 		</dict>
 		<dict>
 			<key>Type</key>
@@ -55,6 +57,8 @@
 			<string>textServer</string>
 			<key>DefaultValue</key>
 			<true/>
+			<key>FooterText</key>
+			<string>chicken</string>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/AltStore/Settings/AnisetteManager.swift
+++ b/AltStore/Settings/AnisetteManager.swift
@@ -12,12 +12,26 @@ public struct AnisetteManager {
     
     /// User defined URL from Settings/UserDefaults
     static var userURL: String? {
-        guard let urlString = UserDefaults.standard.customAnisetteURL, !urlString.isEmpty else { return nil }
+        var urlString: String?
+        
+        if UserDefaults.standard.textServer == false {
+            urlString = UserDefaults.standard.textInputAnisetteURL
+        }
+        else {
+            urlString = UserDefaults.standard.customAnisetteURL
+        }
+            
+        
+        // guard let urlString = UserDefaults.standard.customAnisetteURL, !urlString.isEmpty else { return nil }
+        
         // Test it's a valid URL
-        guard URL(string: urlString) != nil else {
+        
+        if let urlString = urlString {
+            guard URL(string: urlString) != nil else {
             ELOG("UserDefaults has invalid `customAnisetteURL`")
             assertionFailure("UserDefaults has invalid `customAnisetteURL`")
             return nil
+            }
         }
         return urlString
     }

--- a/AltStoreCore/Extensions/UserDefaults+AltStore.swift
+++ b/AltStoreCore/Extensions/UserDefaults+AltStore.swift
@@ -21,6 +21,8 @@ public extension UserDefaults
     
     @NSManaged var firstLaunch: Date?
     @NSManaged var requiresAppGroupMigration: Bool
+    @NSManaged var textServer: Bool
+    @NSManaged var textInputAnisetteURL: String?
     @NSManaged var customAnisetteURL: String?
     @NSManaged var preferredServerID: String?
     


### PR DESCRIPTION
This adds a multiple value specifier for anisette servers of which the following are options

<img src="https://user-images.githubusercontent.com/71040782/205461620-7bad759e-31a3-4a59-b90c-8ecc571c8cfd.jpeg" width=360 height=640>

Also adds a "Danger Zone" for enabling the use of a custom server instead of one of the defaults.

<img src="https://user-images.githubusercontent.com/71040782/205461735-abad351b-e33b-48ff-a3df-bee1df220cc6.jpg" width=360 height=640>

When the "Use preferred servers" toggle is off then it will prefer whatever is inputted into the "Anisette URL" box and if the toggle is enabled it will use whatever is selected from the multiple value specifier