### PR TITLE
Fix .mobiledevicepairing files

### DIFF
--- a/AltStore/LaunchViewController.swift
+++ b/AltStore/LaunchViewController.swift
@@ -83,7 +83,8 @@ class LaunchViewController: RSTLaunchViewController, UIDocumentPickerDelegate
             let ok = UIAlertAction(title: "OK", style: .default, handler: { (action) -> Void in
                 // Try to load it from a file picker
                 var types = UTType.types(tag: "plist", tagClass: UTTagClass.filenameExtension, conformingTo: nil)
-                types.append(contentsOf: UTType.types(tag: "mobiledevicepairing", tagClass: UTTagClass.filenameExtension, conformingTo: nil))
+                types.append(contentsOf: UTType.types(tag: "mobiledevicepairing", tagClass: UTTagClass.filenameExtension, conformingTo: UTType.data))
+                types.append(.xml)
                 let documentPickerController = UIDocumentPickerViewController(forOpeningContentTypes: types)
                 documentPickerController.delegate = self
                 self.present(documentPickerController, animated: true, completion: nil)

--- a/AltStore/LaunchViewController.swift
+++ b/AltStore/LaunchViewController.swift
@@ -141,7 +141,7 @@ class LaunchViewController: RSTLaunchViewController, UIDocumentPickerDelegate
     }
     
     func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
-        displayError("Choosing a pairing file was cancelled")
+        displayError("Choosing a pairing file was cancelled. Please re-open the app and try again.")
     }
     
     func start_minimuxer_threads(_ pairing_file: String) {


### PR DESCRIPTION
This PR addresses #147 by fixing the selection of `.mobiledevicepairing` file in the pairing file popup, and also allowing `.xml` files to be selected. This also adds a more meaningful message to the user when pairing file selection is cancelled.