### PR TITLE
Add various retries throughout the Rust function calls

### DIFF
--- a/AltStore/LaunchViewController.swift
+++ b/AltStore/LaunchViewController.swift
@@ -146,7 +146,13 @@ class LaunchViewController: RSTLaunchViewController, UIDocumentPickerDelegate
     
     func start_minimuxer_threads(_ pairing_file: String) {
         set_usbmuxd_socket()
-        let res = start_minimuxer(pairing_file: pairing_file)
+        var res = start_minimuxer(pairing_file: pairing_file)
+        var attempts = 10
+        while (attempts != 0 && res != 0) {
+            print("start_minimuxer `res` != 0, retry #\(attempts)")
+            res = start_minimuxer(pairing_file: pairing_file)
+            attempts -= 1
+        }
         if res != 0 {
             displayError("minimuxer failed to start. Incorrect arguments were passed.")
         }

--- a/AltStore/Operations/SendAppOperation.swift
+++ b/AltStore/Operations/SendAppOperation.swift
@@ -51,7 +51,13 @@ class SendAppOperation: ResultOperation<()>
             for (index, data) in data.enumerated() {
                 pls[index] = data
             }
+            var attempts = 10
             let res = minimuxer_yeet_app_afc(ns_bundle_ptr, pls, UInt(data.length))
+            while (attempts != 0 && res != 0){
+                print("minimuxer_yeet_app_afc `res` != 0, retry #\(attempts)")
+                let res = minimuxer_yeet_app_afc(ns_bundle_ptr, pls, UInt(data.length))
+                attempts -= 1
+            }
             if res == 0 {
                 self.progress.completedUnitCount += 1
                 self.finish(.success(()))

--- a/minimuxer/minimuxer.swift
+++ b/minimuxer/minimuxer.swift
@@ -27,7 +27,13 @@ public func set_usbmuxd_socket() {
 public func debug_app(app_id: String) throws -> Uhoh {
     let ai = NSString(string: app_id)
     let ai_pointer = UnsafeMutablePointer<CChar>(mutating: ai.utf8String)
-    let res = minimuxer_debug_app(ai_pointer)
+    var res = minimuxer_debug_app(ai_pointer)
+    var attempts = 10
+    while (attempts != 0 && res != 0) {
+        print("(JIT) ATTEMPTS: \(attempts)")
+        res = minimuxer_debug_app(ai_pointer)
+        attempts -= 1
+    }
     if res != 0 {
         throw Uhoh.Bad(code: res)
     }
@@ -39,7 +45,13 @@ public func install_provisioning_profile(plist: Data) throws -> Uhoh {
     print(pls)
     print(plist)
     let x = plist.withUnsafeBytes { buf in UnsafeMutableRawPointer(mutating: buf) }
-    let res = minimuxer_install_provisioning_profile(x, UInt32(plist.count))
+    var res = minimuxer_install_provisioning_profile(x, UInt32(plist.count))
+    var attempts = 10
+    while (attempts != 0 && res != 0) {
+        print("(INSTALL) ATTEMPTS: \(attempts)")
+        res = minimuxer_install_provisioning_profile(x, UInt32(plist.count))
+        attempts -= 1
+    }
     if res != 0 {
         throw Uhoh.Bad(code: res)
     }
@@ -49,7 +61,13 @@ public func install_provisioning_profile(plist: Data) throws -> Uhoh {
 public func remove_provisioning_profile(id: String) throws -> Uhoh {
     let id_ns = NSString(string: id)
     let id_pointer = UnsafeMutablePointer<CChar>(mutating: id_ns.utf8String)
-    let res = minimuxer_remove_provisioning_profile(id_pointer)
+    var res = minimuxer_remove_provisioning_profile(id_pointer)
+    var attempts = 10
+    while (attempts != 0 && res != 0) {
+        print("(REMOVE PROFILE) ATTEMPTS: \(attempts)")
+        res = minimuxer_remove_provisioning_profile(id_pointer)
+        attempts -= 1
+    }
     if res != 0 {
         throw Uhoh.Bad(code: res)
     }
@@ -59,7 +77,13 @@ public func remove_provisioning_profile(id: String) throws -> Uhoh {
 public func remove_app(app_id: String) throws -> Uhoh {
     let ai = NSString(string: app_id)
     let ai_pointer = UnsafeMutablePointer<CChar>(mutating: ai.utf8String)
-    let res = minimuxer_remove_app(ai_pointer)
+    var res = minimuxer_remove_app(ai_pointer)
+    var attempts = 10
+    while (attempts != 0 && res != 0) {
+        print("(REMOVE APP) ATTEMPTS: \(attempts)")
+        res = minimuxer_remove_app(ai_pointer)
+        attempts -= 1
+    }
     if res != 0 {
         throw Uhoh.Bad(code: res)
     }


### PR DESCRIPTION
I currently have this set to retry 10 times per function. We could probably move the retry amount to a const, or some form of setting for the user, but I thought 10 was decent as a default for now. 