### PR TITLE
Add Community store to Trusted Sources

### DIFF
--- a/trustedapps.json
+++ b/trustedapps.json
@@ -5,6 +5,10 @@
       "identifier": "io.sidestore.example"
     },
     {
+      "identifier": "com.sidestoreapps.community",
+      "sourceURL": "https://community-apps.sidestore.io/sidecommunity.json"
+    },
+    {
       "identifier": "org.provenance-emu.provenance",
       "sourceURL": "https://provenance-emu.com/apps.json"
     },


### PR DESCRIPTION
This adds sidestore community store. This change should work but however the store needs to be worked on still so we should merge at a later date.