### PR TITLE
Revamp actions to have stable, beta and nightly builds

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,14 +1,16 @@
-name: Build and Upload SideStore
+name: Beta SideStore build
 on:
   push:
     branches:
-      - master
       - develop
-  pull_request:
 
 jobs:
   build:
-    name: Build and upload SideStore
+    name: Build and upload SideStore Beta
+    if: startsWith(github.event.head_commit.message, '[beta]')
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +80,9 @@ jobs:
       # - name: Build minimuxer
       #   run: cd Dependencies/minimuxer && cargo build --release --target aarch64-apple-ios
 
+      - name: Add beta suffix to version
+        run: sed -e '/MARKETING_VERSION = .*/s/$/-beta.${{ github.run_number }}/' -i '' Build.xcconfig
+
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1.4.1
         with:
@@ -114,6 +119,10 @@ jobs:
           name: SideStore.ipa
           path: SideStore.ipa
 
+      - name: Get version
+        id: version
+        run: echo "version=$(grep MARKETING_VERSION Build.xcconfig | sed -e "s/MARKETING_VERSION = //g")" >> $GITHUB_OUTPUT
+
       - name: Get current date
         id: date
         run: echo "date=$(date -u +'%c')" >> $GITHUB_OUTPUT
@@ -122,21 +131,26 @@ jobs:
         id: date_altstore
         run: echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      - name: Upload to nightly release
+      - name: Upload to beta release
         uses: IsaacShelton/update-existing-release@v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release: "Nightly"
-          tag: "nightly"
+          release: "Beta"
+          tag: "beta"
           prerelease: true
           files: SideStore.ipa
           body: |
-            This is an ⚠️ **EXPERIMENTAL** ⚠️ nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
+            This is an ⚠️ **EXPERIMENTAL** ⚠️ beta build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
             
-            Nightly builds are built from the most recent commit. However, since they are much newer and less tested, they have a much higher chance of bugs, so **use at your own risk**.
+            Beta builds are hand-picked builds from development commits that will allow you to try out new features earlier than normal, but with a lower chance of bugs than if you used nightly builds. However, since these changes are newer and less tested, they still have a good chance of bugs, so **use at your own risk**.
             
-            If you use the `SideStore (Nightly)` app, it will use the latest nightly build (make sure to update it in "My Apps").
+            If you want to be on the bleeding edge and use the latest development builds, you can look at [SideStore Nightly](https://github.com/${{ github.repository }}/releases/tag/nightly). **Please be aware that these builds have a much higher chance of bugs than beta or stable**.
+            
+            If you use the `SideStore (Beta)` app, it will use the latest beta build (make sure to update it in "My Apps").
+            
+            ## Build Info
             
             Built at (UTC): `${{ steps.date.outputs.date }}`
             Built at (UTC date): `${{ steps.date_altstore.outputs.date }}`
             Commit SHA: `${{ github.sha }}`
+            Version: `${{ steps.version.outputs.version }}`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,11 @@ jobs:
         uses: IsaacShelton/update-existing-release@v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release: "Nightly build for ${{ github.sha }}"
+          release: "Nightly"
           tag: "nightly"
           prerelease: true
           files: test.ipa
-          body: >
+          body: |
             This is an __⚠️ **EXPERIMENTAL** ⚠️__ nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
             
             Nightly builds are built from the most recent commit. However, since they are much newer and less tested, they have a much higher chance of bugs, so **use at your own risk**.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,26 +18,33 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
       - name: Test nightly
-        run: touch test.ipa
+        run: echo "test" > test.ipa
 
       - name: Upload to nightly release
         uses: IsaacShelton/update-existing-release@v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release: "Nightly"
+          release: "Nightly build for ${{ github.sha }}"
           tag: "nightly"
           prerelease: true
           files: test.ipa
-          body: "Nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+          body: >
+            This is an __⚠️ **EXPERIMENTAL** ⚠️__ nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
+            
+            Nightly builds are built from the most recent commit. However, since they are much newer and less tested, they have a much higher chance of bugs, so **use at your own risk**.
+            
+            If you use the SideStore (Nightly) app, it will use the latest nightly build.
+            
+            Built at: $(date -u +'%c') (UTC)
 
       - name: Trigger error
         run: exit 1
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
 
       # - name: Cache rust cargo
       #   id: cache-rust-cargo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,23 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Test nightly
+        run: touch test.ipa
+
+      - name: Upload to nightly release
+        uses: IsaacShelton/update-existing-release@v1.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release: "Nightly"
+          tag: "nightly"
+          prerelease: true
+          files: test.ipa
+          message: "Nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+          body: ""
+
+      - name: Trigger error
+        run: exit 1
+
       # - name: Cache rust cargo
       #   id: cache-rust-cargo
       #   uses: actions/cache@v3
@@ -113,3 +130,14 @@ jobs:
         with:
           name: SideStore.ipa
           path: SideStore.ipa
+
+      - name: Upload to nightly release
+        uses: IsaacShelton/update-existing-release@v1.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release: "Nightly"
+          tag: "nightly"
+          prerelease: true
+          files: SideStore.ipa
+          message: "Nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
+          body: ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
         id: date
         run: echo "date=$(date -u +'%c')" >> $GITHUB_OUTPUT
 
+      - name: Get current date in AltStore date form
+        id: date_altstore
+        run: echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
       - name: Upload to nightly release
         uses: IsaacShelton/update-existing-release@v1.3.1
         with:
@@ -34,13 +38,15 @@ jobs:
           prerelease: true
           files: test.ipa
           body: |
-            This is an __⚠️ **EXPERIMENTAL** ⚠️__ nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
+            This is an ⚠️ **EXPERIMENTAL** ⚠️ nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
             
             Nightly builds are built from the most recent commit. However, since they are much newer and less tested, they have a much higher chance of bugs, so **use at your own risk**.
             
             If you use the SideStore (Nightly) app, it will use the latest nightly build (make sure to update it in "My Apps").
             
-            Built at: ${{ steps.date.outputs.date }} (UTC)
+            Built at: `${{ steps.date.outputs.date }}` (UTC)
+            Built at (UTC date): `${{ steps.date.outputs.date_altstore }}`
+            Commit SHA: `${{ github.sha }}`
 
       - name: Trigger error
         run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,7 @@ jobs:
           tag: "nightly"
           prerelease: true
           files: test.ipa
-          message: "Nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
-          body: ""
+          body: "Nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
 
       - name: Trigger error
         run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
             If you use the SideStore (Nightly) app, it will use the latest nightly build (make sure to update it in "My Apps").
             
             Built at: `${{ steps.date.outputs.date }}` (UTC)
-            Built at (UTC date): `${{ steps.date.outputs.date_altstore }}`
+            Built at (UTC date): `${{ steps.date_altstore.outputs.date }}`
             Commit SHA: `${{ github.sha }}`
 
       - name: Trigger error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Test nightly
         run: echo "test" > test.ipa
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +'%c')" >> $GITHUB_OUTPUT
+
       - name: Upload to nightly release
         uses: IsaacShelton/update-existing-release@v1.3.1
         with:
@@ -34,9 +38,9 @@ jobs:
             
             Nightly builds are built from the most recent commit. However, since they are much newer and less tested, they have a much higher chance of bugs, so **use at your own risk**.
             
-            If you use the SideStore (Nightly) app, it will use the latest nightly build.
+            If you use the SideStore (Nightly) app, it will use the latest nightly build (make sure to update it in "My Apps").
             
-            Built at: $(date -u +'%c') (UTC)
+            Built at: ${{ steps.date.outputs.date }} (UTC)
 
       - name: Trigger error
         run: exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,39 +18,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Test nightly
-        run: echo "test" > test.ipa
-
-      - name: Get current date
-        id: date
-        run: echo "date=$(date -u +'%c')" >> $GITHUB_OUTPUT
-
-      - name: Get current date in AltStore date form
-        id: date_altstore
-        run: echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
-      - name: Upload to nightly release
-        uses: IsaacShelton/update-existing-release@v1.3.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          release: "Nightly"
-          tag: "nightly"
-          prerelease: true
-          files: test.ipa
-          body: |
-            This is an ⚠️ **EXPERIMENTAL** ⚠️ nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
-            
-            Nightly builds are built from the most recent commit. However, since they are much newer and less tested, they have a much higher chance of bugs, so **use at your own risk**.
-            
-            If you use the SideStore (Nightly) app, it will use the latest nightly build (make sure to update it in "My Apps").
-            
-            Built at: `${{ steps.date.outputs.date }}` (UTC)
-            Built at (UTC date): `${{ steps.date_altstore.outputs.date }}`
-            Commit SHA: `${{ github.sha }}`
-
-      - name: Trigger error
-        run: exit 1
-
       - name: Checkout code
         uses: actions/checkout@v2
         with:
@@ -147,6 +114,14 @@ jobs:
           name: SideStore.ipa
           path: SideStore.ipa
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +'%c')" >> $GITHUB_OUTPUT
+
+      - name: Get current date in AltStore date form
+        id: date_altstore
+        run: echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
       - name: Upload to nightly release
         uses: IsaacShelton/update-existing-release@v1.3.1
         with:
@@ -155,5 +130,13 @@ jobs:
           tag: "nightly"
           prerelease: true
           files: SideStore.ipa
-          message: "Nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})"
-          body: ""
+          body: |
+            This is an ⚠️ **EXPERIMENTAL** ⚠️ nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
+            
+            Nightly builds are built from the most recent commit. However, since they are much newer and less tested, they have a much higher chance of bugs, so **use at your own risk**.
+            
+            If you use the `SideStore (Nightly)` app, it will use the latest nightly build (make sure to update it in "My Apps").
+            
+            Built at (UTC): `${{ steps.date.outputs.date }}`
+            Built at (UTC date): `${{ steps.date_altstore.outputs.date }}`
+            Commit SHA: `${{ github.sha }}`

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,155 @@
+name: Nightly SideStore build
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    name: Build and upload SideStore Nightly
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: 'macos-12'
+            version: '14.2'
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      # - name: Cache rust cargo
+      #   id: cache-rust-cargo
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-cargo
+      #   with:
+      #     path: ~/.cargo
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      # - name: Cache rust minimuxer
+      #   id: cache-rust-minimuxer
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-minimuxer
+      #   with:
+      #     path: ./Dependencies/minimuxer/target
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      # - name: Cache rust em_proxy
+      #   id: cache-rust-em_proxy
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-em_proxy
+      #   with:
+      #     path: ./Dependencies/em_proxy/target
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: brew install ldid
+
+      - name: Install rustup
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          target: aarch64-apple-ios
+
+      # - name: Create emotional damage
+      #   run: cd Dependencies/em_proxy && cargo build --release --target aarch64-apple-ios
+
+      # - name: Build minimuxer
+      #   run: cd Dependencies/minimuxer && cargo build --release --target aarch64-apple-ios
+
+      - name: Add nightly suffix to version
+        run: sed -e '/MARKETING_VERSION = .*/s/$/-nightly.${{ github.run_number }}/' -i '' Build.xcconfig
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1.4.1
+        with:
+          xcode-version: ${{ matrix.version }}
+
+      - name: Build SideStore
+        run: |
+          xcodebuild -project AltStore.xcodeproj \
+          -scheme AltStore \
+          -sdk iphoneos \
+          archive -archivePath ./archive \
+          CODE_SIGNING_REQUIRED=NO \
+          AD_HOC_CODE_SIGNING_ALLOWED=YES \
+          CODE_SIGNING_ALLOWED=NO \
+          DEVELOPMENT_TEAM=XYZ0123456 \
+          ORG_IDENTIFIER=com.SideStore \
+          | xcpretty && exit ${PIPESTATUS[0]}
+
+      - name: Fakesign app
+        run: |
+          rm -rf archive.xcarchive/Products/Applications/SideStore.app/Frameworks/AltStoreCore.framework/Frameworks/
+          ldid -SAltStore/Resources/tempEnt.plist archive.xcarchive/Products/Applications/SideStore.app/SideStore
+
+      - name: Convert to IPA
+        run: |
+          mkdir Payload
+          mkdir Payload/SideStore.app
+          cp -R archive.xcarchive/Products/Applications/SideStore.app/ Payload/SideStore.app/
+          zip -r SideStore.ipa Payload
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: SideStore.ipa
+          path: SideStore.ipa
+
+      - name: Get version
+        id: version
+        run: echo "version=$(grep MARKETING_VERSION Build.xcconfig | sed -e "s/MARKETING_VERSION = //g")" >> $GITHUB_OUTPUT
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +'%c')" >> $GITHUB_OUTPUT
+
+      - name: Get current date in AltStore date form
+        id: date_altstore
+        run: echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Upload to nightly release
+        uses: IsaacShelton/update-existing-release@v1.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release: "Nightly"
+          tag: "nightly"
+          prerelease: true
+          files: SideStore.ipa
+          body: |
+            This is an ⚠️ **EXPERIMENTAL** ⚠️ nightly build for commit [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }}).
+            
+            Nightly builds are built from the most recent commit which means you'll be able to try out new features very early. However, since these changes are much newer and less tested, they have a much higher chance of bugs, so **use at your own risk**.
+            
+            If you want to try out new features early but want a lower chance of bugs, you can look at [SideStore Beta](https://github.com/${{ github.repository }}/releases/tag/beta).
+            
+            If you use the `SideStore (Nightly)` app, it will use the latest nightly build (make sure to update it in "My Apps").
+            
+            ## Build Info
+            
+            Built at (UTC): `${{ steps.date.outputs.date }}`
+            Built at (UTC date): `${{ steps.date_altstore.outputs.date }}`
+            Commit SHA: `${{ github.sha }}`
+            Version: `${{ steps.version.outputs.version }}`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,111 @@
+name: Pull Request SideStore build
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Build and upload SideStore
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: 'macos-12'
+            version: '14.2'
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      # - name: Cache rust cargo
+      #   id: cache-rust-cargo
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-cargo
+      #   with:
+      #     path: ~/.cargo
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      # - name: Cache rust minimuxer
+      #   id: cache-rust-minimuxer
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-minimuxer
+      #   with:
+      #     path: ./Dependencies/minimuxer/target
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      # - name: Cache rust em_proxy
+      #   id: cache-rust-em_proxy
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-em_proxy
+      #   with:
+      #     path: ./Dependencies/em_proxy/target
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: brew install ldid
+
+      - name: Install rustup
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          target: aarch64-apple-ios
+
+      # - name: Create emotional damage
+      #   run: cd Dependencies/em_proxy && cargo build --release --target aarch64-apple-ios
+
+      # - name: Build minimuxer
+      #   run: cd Dependencies/minimuxer && cargo build --release --target aarch64-apple-ios
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1.4.1
+        with:
+          xcode-version: ${{ matrix.version }}
+
+      - name: Build SideStore
+        run: |
+          xcodebuild -project AltStore.xcodeproj \
+          -scheme AltStore \
+          -sdk iphoneos \
+          archive -archivePath ./archive \
+          CODE_SIGNING_REQUIRED=NO \
+          AD_HOC_CODE_SIGNING_ALLOWED=YES \
+          CODE_SIGNING_ALLOWED=NO \
+          DEVELOPMENT_TEAM=XYZ0123456 \
+          ORG_IDENTIFIER=com.SideStore \
+          | xcpretty && exit ${PIPESTATUS[0]}
+
+      - name: Fakesign app
+        run: |
+          rm -rf archive.xcarchive/Products/Applications/SideStore.app/Frameworks/AltStoreCore.framework/Frameworks/
+          ldid -SAltStore/Resources/tempEnt.plist archive.xcarchive/Products/Applications/SideStore.app/SideStore
+
+      - name: Convert to IPA
+        run: |
+          mkdir Payload
+          mkdir Payload/SideStore.app
+          cp -R archive.xcarchive/Products/Applications/SideStore.app/ Payload/SideStore.app/
+          zip -r SideStore.ipa Payload
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: SideStore.ipa
+          path: SideStore.ipa

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -1,0 +1,145 @@
+name: Stable SideStore build
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  build:
+    name: Build and upload SideStore
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: 'macos-12'
+            version: '14.2'
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      # - name: Cache rust cargo
+      #   id: cache-rust-cargo
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-cargo
+      #   with:
+      #     path: ~/.cargo
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      # - name: Cache rust minimuxer
+      #   id: cache-rust-minimuxer
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-minimuxer
+      #   with:
+      #     path: ./Dependencies/minimuxer/target
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      # - name: Cache rust em_proxy
+      #   id: cache-rust-em_proxy
+      #   uses: actions/cache@v3
+      #   env:
+      #     cache-name: cache-rust-em_proxy
+      #   with:
+      #     path: ./Dependencies/em_proxy/target
+      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      #       ${{ runner.os }}-build-
+      #       ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: brew install ldid
+
+      - name: Install rustup
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          target: aarch64-apple-ios
+
+      # - name: Create emotional damage
+      #   run: cd Dependencies/em_proxy && cargo build --release --target aarch64-apple-ios
+
+      # - name: Build minimuxer
+      #   run: cd Dependencies/minimuxer && cargo build --release --target aarch64-apple-ios
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1.4.1
+        with:
+          xcode-version: ${{ matrix.version }}
+
+      - name: Build SideStore
+        run: |
+          xcodebuild -project AltStore.xcodeproj \
+          -scheme AltStore \
+          -sdk iphoneos \
+          archive -archivePath ./archive \
+          CODE_SIGNING_REQUIRED=NO \
+          AD_HOC_CODE_SIGNING_ALLOWED=YES \
+          CODE_SIGNING_ALLOWED=NO \
+          DEVELOPMENT_TEAM=XYZ0123456 \
+          ORG_IDENTIFIER=com.SideStore \
+          | xcpretty && exit ${PIPESTATUS[0]}
+
+      - name: Fakesign app
+        run: |
+          rm -rf archive.xcarchive/Products/Applications/SideStore.app/Frameworks/AltStoreCore.framework/Frameworks/
+          ldid -SAltStore/Resources/tempEnt.plist archive.xcarchive/Products/Applications/SideStore.app/SideStore
+
+      - name: Convert to IPA
+        run: |
+          mkdir Payload
+          mkdir Payload/SideStore.app
+          cp -R archive.xcarchive/Products/Applications/SideStore.app/ Payload/SideStore.app/
+          zip -r SideStore.ipa Payload
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: SideStore.ipa
+          path: SideStore.ipa
+
+      - name: Get version
+        id: version
+        run: echo "version=$(grep MARKETING_VERSION Build.xcconfig | sed -e "s/MARKETING_VERSION = //g")" >> $GITHUB_OUTPUT
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +'%c')" >> $GITHUB_OUTPUT
+
+      - name: Get current date in AltStore date form
+        id: date_altstore
+        run: echo "date=$(date -u +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Upload to new stable release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ steps.version.outputs.version }}
+          tag_name: ${{ github.ref }}
+          draft: true
+          files: SideStore.ipa
+          body: |
+            ## Changelog
+            
+            - TODO
+            
+            ## Build Info
+            
+            Built at (UTC): `${{ steps.date.outputs.date }}`
+            Built at (UTC date): `${{ steps.date_altstore.outputs.date }}`
+            Commit SHA: `${{ github.sha }}`
+            Version: `${{ steps.version.outputs.version }}`


### PR DESCRIPTION
Update workflow info/notes: https://github.com/SideStore/SideStore/pull/210#issuecomment-1369432170

~~This PR adds some functionality to the GitHub Actions workflow that will upload the built .ipa to a "nightly" release (you can see what it would look like [here](https://github.com/naturecodevoid/SideStore/releases/tag/nightly)).~~ However, you may be wondering why since it already uploads the .ipa as an artifact. Here are some things we can do with a release that would not be possible (or harder to implement) with artifacts:
- Users do not need a github account to download the .ipa
- A simple cloudflare worker could be created that fetches the nightly release from GitHub and responds with an altstore/sidestore source with the latest nightly build, and also the latest stable release. (I can also make this if it seems like a good addition.)
  - This is currently not possible with artifacts because artifacts are only downloadable in .zip format, which is currently not compatible with SideStore.
  - I've also added some info to the release body that would make it much easier to parse for the necessary information needed for an altstore app/version. (It can easily be split by "`" for the date and commit SHA. We can then use github's API to get the commit name for a version description)
  - GitHub's API also makes it incredibly easy to get the nightly release since we can just look for a release with the nightly tag (https://api.github.com/repos/naturecodevoid/SideStore/releases/tags/nightly)