### PR TITLE
Release channel support

### DIFF
--- a/AltStore/Browse/BrowseViewController.swift
+++ b/AltStore/Browse/BrowseViewController.swift
@@ -77,7 +77,7 @@ private extension BrowseViewController
                                         NSSortDescriptor(keyPath: \StoreApp.name, ascending: true),
                                         NSSortDescriptor(keyPath: \StoreApp.bundleIdentifier, ascending: true)]
         fetchRequest.returnsObjectsAsFaults = false
-        fetchRequest.predicate = NSPredicate(format: "%K != %@", #keyPath(StoreApp.bundleIdentifier), StoreApp.altstoreAppID)
+        fetchRequest.predicate = NSPredicate(format: "%K != %@", #keyPath(StoreApp.sourceIdentifier), Source.altStoreIdentifier)
         
         let dataSource = RSTFetchedResultsCollectionViewPrefetchingDataSource<StoreApp, UIImage>(fetchRequest: fetchRequest, managedObjectContext: DatabaseManager.shared.viewContext)
         dataSource.cellConfigurationHandler = { (cell, app, indexPath) in

--- a/AltStoreCore/Model/AltStore.xcdatamodeld/AltStore 11.xcdatamodel/contents
+++ b/AltStoreCore/Model/AltStore.xcdatamodeld/AltStore 11.xcdatamodel/contents
@@ -103,6 +103,7 @@
         <attribute name="externalURL" optional="YES" attributeType="URI"/>
         <attribute name="identifier" attributeType="String"/>
         <attribute name="imageURL" optional="YES" attributeType="URI"/>
+        <attribute name="isDuplicate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isSilent" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="sortIndex" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="sourceIdentifier" optional="YES" attributeType="String"/>

--- a/AltStoreCore/Model/DatabaseManager.swift
+++ b/AltStoreCore/Model/DatabaseManager.swift
@@ -222,7 +222,7 @@ private extension DatabaseManager
             
             let storeApp: StoreApp
             
-            if let app = StoreApp.first(satisfying: NSPredicate(format: "%K == %@", #keyPath(StoreApp.bundleIdentifier), StoreApp.altstoreAppID), in: context)
+            if let app = StoreApp.first(satisfying: NSPredicate(format: "%K == %@ AND %K == %@", #keyPath(StoreApp.bundleIdentifier), StoreApp.altstoreAppID, #keyPath(StoreApp.sourceIdentifier), Source.altStoreIdentifier), in: context)
             {
                 storeApp = app
             }

--- a/AltStoreCore/Model/InstalledApp.swift
+++ b/AltStoreCore/Model/InstalledApp.swift
@@ -108,6 +108,10 @@ public class InstalledApp: NSManagedObject, InstalledAppProtocol
     public func update(resignedApp: ALTApplication, certificateSerialNumber: String?)
     {
         self.name = resignedApp.name
+        if storeApp != nil {
+            // This might break things; maybe only do this if the bundle ID is SideStore's?
+            self.name = storeApp!.name // If we don't do this, the name will always be SideStore in My Apps, even when using beta/nightly
+        }
         
         self.resignedBundleIdentifier = resignedApp.bundleIdentifier
         self.version = resignedApp.version
@@ -178,7 +182,7 @@ public extension InstalledApp
     
     class func fetchAltStore(in context: NSManagedObjectContext) -> InstalledApp?
     {
-        let predicate = NSPredicate(format: "%K == %@", #keyPath(InstalledApp.bundleIdentifier), StoreApp.altstoreAppID)
+        let predicate = NSPredicate(format: "%K == %@ AND %K != nil AND %K == %@", #keyPath(InstalledApp.bundleIdentifier), StoreApp.altstoreAppID, #keyPath(InstalledApp.storeApp), #keyPath(InstalledApp.storeApp.sourceIdentifier), Source.altStoreIdentifier)
         print("Fetch 'AltStore' Predicate: \(String(describing: predicate))")
         let altStore = InstalledApp.first(satisfying: predicate, in: context)
         return altStore

--- a/AltStoreCore/Model/NewsItem.swift
+++ b/AltStoreCore/Model/NewsItem.swift
@@ -32,6 +32,15 @@ public class NewsItem: NSManagedObject, Decodable, Fetchable
     @NSManaged public var storeApp: StoreApp?
     @NSManaged public var source: Source?
     
+    @objc public var isDuplicate: Bool {
+        if self.source == nil { return false }
+        
+        // Hide news from sources that begin with the SideStore identifier, and aren't from the same source as the current SideStore source
+        if self.source!.identifier.starts(with: Bundle.Info.appbundleIdentifier) && self.source!.identifier != Source.altStoreIdentifier { return true }
+        
+        return false
+    }
+    
     private enum CodingKeys: String, CodingKey
     {
         case identifier
@@ -86,6 +95,9 @@ public extension NewsItem
 {
     @nonobjc class func fetchRequest() -> NSFetchRequest<NewsItem>
     {
-        return NSFetchRequest<NewsItem>(entityName: "NewsItem")
+        let fetchRequest = NSFetchRequest<NewsItem>(entityName: "NewsItem")
+        fetchRequest.predicate = NSPredicate(format: "%K == NO",
+                                             #keyPath(NewsItem.isDuplicate))
+        return fetchRequest
     }
 }

--- a/AltStoreCore/Model/Source.swift
+++ b/AltStoreCore/Model/Source.swift
@@ -11,29 +11,37 @@ import UIKit
 
 public extension Source
 {
-    #if ALPHA
-    static let altStoreIdentifier = Bundle.Info.appbundleIdentifier
-    #else
-    static let altStoreIdentifier = Bundle.Info.appbundleIdentifier
-    #endif
+    static var altStoreIdentifier: String {
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        
+        if appVersion != nil {
+            if appVersion!.contains("beta") {
+                return Bundle.Info.appbundleIdentifier + ".Beta"
+            }
+            if appVersion!.contains("nightly") {
+                return Bundle.Info.appbundleIdentifier + ".Nightly"
+            }
+        }
+        
+        return Bundle.Info.appbundleIdentifier
+    }
     
-    #if STAGING
+    static let altStoreSourceBaseURL = "https://sidestore-apps.naturecodevoid.dev/"
     
-    #if ALPHA
-    static let altStoreSourceURL = URL(string: "https://apps.sidestore.io/")!
-    #else
-    static let altStoreSourceURL = URL(string: "https://apps.sidestore.io/")!
-    #endif
-    
-    #else
-    
-    #if ALPHA
-    static let altStoreSourceURL = URL(string: "https://apps.sidestore.io/")!
-    #else
-    static let altStoreSourceURL = URL(string: "https://apps.sidestore.io/")!
-    #endif
-    
-    #endif
+    static var altStoreSourceURL: URL {
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        
+        if appVersion != nil {
+            if appVersion!.contains("beta") {
+                return URL(string: altStoreSourceBaseURL + "beta")!
+            }
+            if appVersion!.contains("nightly") {
+                return URL(string: altStoreSourceBaseURL + "nightly")!
+            }
+        }
+        
+        return URL(string: altStoreSourceBaseURL)!
+    }
 }
 
 public struct AppPermissionFeed: Codable {

--- a/AltStoreCore/Model/StoreApp.swift
+++ b/AltStoreCore/Model/StoreApp.swift
@@ -343,16 +343,28 @@ public extension StoreApp
     {
         let app = StoreApp(context: context)
         app.name = "SideStore"
+        
+        let currentAppVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        
+        if currentAppVersion != nil {
+            if currentAppVersion!.contains("beta") {
+                app.name += " (Beta)"
+            }
+            if currentAppVersion!.contains("nightly") {
+                app.name += " (Nightly)"
+            }
+        }
+        
         app.bundleIdentifier = StoreApp.altstoreAppID
-        app.developerName = "Side Team"
-        app.localizedDescription = "SideStore is an alternative App Store."
-        app.iconURL = URL(string: "https://user-images.githubusercontent.com/705880/63392210-540c5980-c37b-11e9-968c-8742fc68ab2e.png")!
+        app.developerName = "SideStore Team"
+        app.localizedDescription = "SideStore is an alternative app store for non-jailbroken devices.\n\nSideStore allows you to sideload other .ipa files and apps from the Files app or via the SideStore Library."
+        app.iconURL = URL(string: "https://sidestore.io/assets/icon.png")!
         app.screenshotURLs = []
         app.sourceIdentifier = Source.altStoreIdentifier
         
-        let appVersion = AppVersion.makeAppVersion(version: "0.3.0",
+        let appVersion = AppVersion.makeAppVersion(version: "0.0.0", // this is set to the current app version later
                                                    date: Date(),
-                                                   downloadURL: URL(string: "http://rileytestut.com")!,
+                                                   downloadURL: URL(string: "https://sidestore.io")!,
                                                    size: 0,
                                                    appBundleID: app.bundleIdentifier,
                                                    sourceID: Source.altStoreIdentifier,
@@ -360,10 +372,6 @@ public extension StoreApp
         app.setVersions([appVersion])
         
         print("makeAltStoreApp StoreApp: \(String(describing: app))")
-        
-        #if BETA
-        app.isBeta = true
-        #endif
         
         return app
     }

--- a/trustedapps.json
+++ b/trustedapps.json
@@ -5,6 +5,14 @@
       "identifier": "io.sidestore.example"
     },
     {
+      "identifier": "com.SideStore.SideStore",
+      "sourceURL": "https://sidestore-apps.naturecodevoid.dev/"
+    },
+    {
+      "identifier": "com.SideStore.SideStore.Beta",
+      "sourceURL": "https://sidestore-apps.naturecodevoid.dev/beta"
+    },
+    {
       "identifier": "com.sidestoreapps.community",
       "sourceURL": "https://community-apps.sidestore.io/sidecommunity.json"
     },


### PR DESCRIPTION
This PR changes the following:
- Adapt SideStore source URL and source ID based on if “beta” or “nightly” is in the current version
- Only hide SideStore in Browse if source ID is the same as the current SideStore source ID
- When getting SideStore app, also check if source IDs match up
- Use StoreApp.name for InstalledApp.name to make (Beta)/(Nightly) suffix show up in My Apps

You can test it by adding https://sidestore-apps.naturecodevoid.dev/nightly or https://sidestore-apps.naturecodevoid.dev/beta as a source. Currently, both point to the latest nightly build. ~~We might want to add something that adds the beta/nightly sources to trusted sources **at runtime**. If we just add it to trustedapps.json, there might be conflicts~~