### PR TITLE
Fix 'The name for this app is invalid' error

### DIFF
--- a/AltStore/Operations/FetchProvisioningProfilesOperation.swift
+++ b/AltStore/Operations/FetchProvisioningProfilesOperation.swift
@@ -268,8 +268,17 @@ extension FetchProvisioningProfilesOperation
                             }
                         }
                     }
+                    //App ID name must be ascii. If the name is not ascii, using bundleID instead
+                    let appIDName: String
+                    if containsNonASCII(text: name) {
+                        //Contains non ASCII (Such as Chinese/Japanese...), using bundleID
+                        appIDName = bundleIdentifier
+                    }else {
+                        //ASCII text, keep going as usual
+                        appIDName = name
+                    }
                     
-                    ALTAppleAPI.shared.addAppID(withName: name, bundleIdentifier: bundleIdentifier, team: team, session: session) { (appID, error) in
+                    ALTAppleAPI.shared.addAppID(withName: appIDName, bundleIdentifier: bundleIdentifier, team: team, session: session) { (appID, error) in
                         do
                         {
                             do
@@ -513,4 +522,14 @@ extension FetchProvisioningProfilesOperation
             }
         }
     }
+}
+
+func containsNonASCII(text: String) -> Bool {
+    let ascii = CharacterSet(charactersIn: "\0"..."~")
+    for scalar in text.unicodeScalars {
+        if !ascii.contains(scalar) {
+            return true
+        }
+    }
+    return false
 }

--- a/AltStore/Operations/FetchProvisioningProfilesOperation.swift
+++ b/AltStore/Operations/FetchProvisioningProfilesOperation.swift
@@ -270,7 +270,7 @@ extension FetchProvisioningProfilesOperation
                     }
                     //App ID name must be ascii. If the name is not ascii, using bundleID instead
                     let appIDName: String
-                    if containsNonASCII(text: name) {
+                    if !name.allSatisfy({ $0.isASCII }) {
                         //Contains non ASCII (Such as Chinese/Japanese...), using bundleID
                         appIDName = bundleIdentifier
                     }else {
@@ -522,14 +522,4 @@ extension FetchProvisioningProfilesOperation
             }
         }
     }
-}
-
-func containsNonASCII(text: String) -> Bool {
-    let ascii = CharacterSet(charactersIn: "\0"..."~")
-    for scalar in text.unicodeScalars {
-        if !ascii.contains(scalar) {
-            return true
-        }
-    }
-    return false
 }


### PR DESCRIPTION
This error is related to App ID creation failure.
App ID name must be an ascii text. It is not allowed to create an App ID with non-ascii text like Chinese, Japanese. If the name is NOT an ascii text, using bundleID instead.

### Changes

- Fix 'The name for this app is invalid' error
