### PR TITLE
[Patch] Fix minimuxer retries to be more stable

### DIFF
--- a/AltStore/Operations/BackupAppOperation.swift
+++ b/AltStore/Operations/BackupAppOperation.swift
@@ -43,10 +43,7 @@ class BackupAppOperation: ResultOperation<Void>
         
         do
         {
-            if let error = self.context.error
-            {
-                throw error
-            }
+            if let error = self.context.error { throw error }
             
             guard let installedApp = self.context.installedApp, let context = installedApp.managedObjectContext else { throw OperationError.invalidParameters }
             context.perform {

--- a/AltStore/Operations/DeactivateAppOperation.swift
+++ b/AltStore/Operations/DeactivateAppOperation.swift
@@ -31,10 +31,7 @@ final class DeactivateAppOperation: ResultOperation<InstalledApp>
     {
         super.main()
         
-        if let error = self.context.error
-        {
-            return self.finish(.failure(error))
-        }
+        if let error = self.context.error { return self.finish(.failure(error)) }
         
         DatabaseManager.shared.persistentContainer.performBackgroundTask { (context) in
             let installedApp = context.object(with: self.app.objectID) as! InstalledApp
@@ -42,13 +39,21 @@ final class DeactivateAppOperation: ResultOperation<InstalledApp>
             let allIdentifiers = [installedApp.resignedBundleIdentifier] + appExtensionProfiles
             
             for profile in allIdentifiers {
-                do {
-                    try remove_provisioning_profile(profile)
-                    self.progress.completedUnitCount += 1
-                    installedApp.isActive = false
-                    return self.finish(.success(installedApp))
-                } catch {
-                    return self.finish(.failure(error))
+                var attempts = 5
+                while (attempts > 0){
+                    print("Remove Provisioning profile attempts left: \(attempts)")
+                    do {
+                        try remove_provisioning_profile(profile)
+                        self.progress.completedUnitCount += 1
+                        installedApp.isActive = false
+                        self.finish(.success(installedApp))
+                        break
+                    } catch {
+                        attempts -= 1
+                        if (attempts <= 0){
+                            self.finish(.failure(error))
+                        }
+                    }
                 }
             }
         }

--- a/AltStore/Operations/EnableJITOperation.swift
+++ b/AltStore/Operations/EnableJITOperation.swift
@@ -45,13 +45,19 @@ final class EnableJITOperation<Context: EnableJITContext>: ResultOperation<Void>
         guard let installedApp = self.context.installedApp else { return self.finish(.failure(OperationError.invalidParameters)) }
         
         installedApp.managedObjectContext?.perform {
-            do {
-                try debug_app(installedApp.resignedBundleIdentifier)
-            } catch {
-                return self.finish(.failure(error))
+            var retries = 3
+            while (retries > 0){
+                do {
+                    try debug_app(installedApp.resignedBundleIdentifier)
+                    self.finish(.success(()))
+                    break
+                } catch {
+                    retries -= 1
+                    if (retries <= 0){
+                        return self.finish(.failure(error))
+                    }
+                }
             }
-            
-            self.finish(.success(()))
         }
     }
 }

--- a/AltStore/Operations/EnableJITOperation.swift
+++ b/AltStore/Operations/EnableJITOperation.swift
@@ -54,7 +54,7 @@ final class EnableJITOperation<Context: EnableJITContext>: ResultOperation<Void>
                 } catch {
                     retries -= 1
                     if (retries <= 0){
-                        return self.finish(.failure(error))
+                        self.finish(.failure(error))
                     }
                 }
             }

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -169,12 +169,9 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
 
                             let content = UNMutableNotificationContent()
                             content.title = "Refreshing..."
-                            content.body = "To finish refreshing, SideStore must be moved to the background, which it does by going to the home screen. Please reopen SideStore after it is done refreshing!"
+                            content.body = "To finish refreshing SideStore must go to the home screen. Please reopen after!"
                             let notification = UNNotificationRequest(identifier: Bundle.Info.appbundleIdentifier + ".FinishRefreshNotification", content: content, trigger: UNTimeIntervalNotificationTrigger(timeInterval: 2, repeats: false))
                             UNUserNotificationCenter.current().add(notification)
-
-                            UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
-
                             break
                         default:
                             print("Notifications are not enabled")
@@ -194,11 +191,11 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
                                     topController.present(alert, animated: true)
                                 } else {
                                     print("No key window? Let's just go home")
-                                    UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
                                 }
                             }
                         }
                     }
+                    UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
                 }
             }
             var attempts = 10

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -175,7 +175,8 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
                     self.finish(.success(installedApp))
                     break
                 } catch {
-                    if (attempts == 0){
+                    attempts -= 1
+                    if (attempts <= 0){
                         installing = false
                         self.finish(.failure(MinimuxerError.InstallApp))
                     }

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -150,7 +150,7 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             }
             
             var installing = true
-            if installedApp.storeApp?.bundleIdentifier == Bundle.Info.appbundleIdentifier {
+            if installedApp.storeApp?.bundleIdentifier.range(of: Bundle.Info.appbundleIdentifier) != nil {
                 // Reinstalling ourself will hang until we leave the app, so we need to exit it without force closing
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                     if UIApplication.shared.applicationState != .active {
@@ -172,12 +172,13 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
                     try install_ipa(installedApp.bundleIdentifier)
                     installing = false
                     installedApp.refreshedDate = Date()
-                    return self.finish(.success(installedApp))
+                    self.finish(.success(installedApp))
+                    break
                 } catch {
                     if (attempts == 0){
                         installing = false
-                        return self.finish(.failure(error))
-                    } else { attempts -= 1 }
+                        self.finish(.failure(MinimuxerError.InstallApp))
+                    }
                 }
             }
         }

--- a/AltStore/Operations/RefreshAppOperation.swift
+++ b/AltStore/Operations/RefreshAppOperation.swift
@@ -40,21 +40,31 @@ final class RefreshAppOperation: ResultOperation<InstalledApp>
             guard let profiles = self.context.provisioningProfiles else { return self.finish(.failure(OperationError.invalidParameters)) }
             guard let app = self.context.app else { return self.finish(.failure(OperationError.appNotFound)) }
             
-            DatabaseManager.shared.persistentContainer.performBackgroundTask { (context) in
-                print("Sending refresh app request...")
-                
-                for p in profiles {
+            for p in profiles {
+                var attempts = 5
+                while (attempts > 0){
+                    print("Install provisioning profile attempts left: \(attempts)")
                     do {
                         let bytes = p.value.data.toRustByteSlice()
                         try install_provisioning_profile(bytes.forRust())
+                        break
                     } catch {
-                        return self.finish(.failure(error))
+                        attempts -= 1
+                        if (attempts <= 0) {
+                            self.finish(.failure(MinimuxerError.ProfileInstall))
+                        }
                     }
+                }
+
+                DatabaseManager.shared.persistentContainer.performBackgroundTask { (context) in
+                print("Sending refresh app request...")
+                    
                     self.progress.completedUnitCount += 1
                     
                     let predicate = NSPredicate(format: "%K == %@", #keyPath(InstalledApp.bundleIdentifier), app.bundleIdentifier)
                     self.managedObjectContext.perform {
                         guard let installedApp = InstalledApp.first(satisfying: predicate, in: self.managedObjectContext) else {
+                            self.finish(.failure(OperationError.appNotFound))
                             return
                         }
                         installedApp.update(provisioningProfile: p.value)

--- a/AltStore/Operations/SendAppOperation.swift
+++ b/AltStore/Operations/SendAppOperation.swift
@@ -51,18 +51,21 @@ final class SendAppOperation: ResultOperation<()>
                 do {
                     let bytes = Data(data).toRustByteSlice()
                     try yeet_app_afc(app.bundleIdentifier, bytes.forRust())
+                    self.progress.completedUnitCount += 1
+                    self.finish(.success(()))
+                    break
                 } catch {
                     attempts -= 1
                     if (attempts == 0) {
-                        return self.finish(.failure(error))
-                    } else { continue }
+                        self.finish(.failure(MinimuxerError.RwAfc))
+                    }
                 }
                 self.progress.completedUnitCount += 1
                 return self.finish(.success(()))
             }
         } else {
             print("IPA doesn't exist????")
-            return self.finish(.failure(ALTServerError(.underlyingError)))
+            self.finish(.failure(OperationError.appNotFound))
         }
     }
 }

--- a/AltStore/Operations/SendAppOperation.swift
+++ b/AltStore/Operations/SendAppOperation.swift
@@ -56,12 +56,12 @@ final class SendAppOperation: ResultOperation<()>
                     break
                 } catch {
                     attempts -= 1
-                    if (attempts == 0) {
+                    if (attempts <= 0) {
                         self.finish(.failure(MinimuxerError.RwAfc))
                     }
                 }
                 self.progress.completedUnitCount += 1
-                return self.finish(.success(()))
+                self.finish(.success(()))
             }
         } else {
             print("IPA doesn't exist????")


### PR DESCRIPTION
### Fix minimuxer retries to be more stable

<!-- Fill this list with what your PR changes. Example: -->
- Fix minimuxer retries throughout the codebase
- Re-add the UI when SideStore refreshes itself alerting the user we have to close to do so

<!-- If your PR is ready to be merged, you can remove this section. -->
### Todo before merge

<!-- Example: -->
- [ ] Testing
- [ ] Review