### PR TITLE
Use provisioning profile details instead of guessing active app limit

### DIFF
--- a/AltStore/My Apps/MyAppsViewController.swift
+++ b/AltStore/My Apps/MyAppsViewController.swift
@@ -1460,7 +1460,7 @@ extension MyAppsViewController
                 let registeredAppIDs = team.appIDs.count
                 
                 let maximumAppIDCount = 10
-                let remainingAppIDs = max(maximumAppIDCount - registeredAppIDs, 0)
+                let remainingAppIDs = maximumAppIDCount - registeredAppIDs
                 
                 if remainingAppIDs == 1
                 {
@@ -1471,7 +1471,7 @@ extension MyAppsViewController
                     footerView.textLabel.text = String(format: NSLocalizedString("%@ App IDs Remaining", comment: ""), NSNumber(value: remainingAppIDs))
                 }
                 
-                footerView.textLabel.isHidden = false
+                footerView.textLabel.isHidden = remainingAppIDs < 0
                 
             case .individual, .organization, .unknown: footerView.textLabel.isHidden = true
             @unknown default: break

--- a/AltStore/Operations/FetchProvisioningProfilesOperation.swift
+++ b/AltStore/Operations/FetchProvisioningProfilesOperation.swift
@@ -262,10 +262,6 @@ extension FetchProvisioningProfilesOperation
                             {
                                 throw OperationError.maximumAppIDLimitReached(application: application, requiredAppIDs: requiredAppIDs, availableAppIDs: availableAppIDs, nextExpirationDate: expirationDate)
                             }
-                            else
-                            {
-                                throw ALTAppleAPIError(.maximumAppIDLimitReached)
-                            }
                         }
                     }
                     //App ID name must be ascii. If the name is not ascii, using bundleID instead


### PR DESCRIPTION
### Changes

- Modifying checks done before app installation; we now look at whether the provisioning profile we actually get is a free one, instead of relying on the account type.
  - Tested with my personal (expired developer) account, this change allows me to install any number of apps. Previously, I would get app ID limit errors, and a prompt to deactivate apps to stay under the 3 app limit.
  - Also tested a free account to confirm that checks are still in place there.

<!-- If your PR doesn't close an issue, you can remove the next line. -->
Fixes #410
