### PR TITLE
Better pairing file info

### DIFF
--- a/AltStore/LaunchViewController.swift
+++ b/AltStore/LaunchViewController.swift
@@ -159,7 +159,7 @@ final class LaunchViewController: RSTLaunchViewController, UIDocumentPickerDeleg
         } else {
             // Show an alert explaining the pairing file
             // Create new Alert
-            let dialogMessage = UIAlertController(title: "Pairing File", message: "Select the pairing file for your device. For more information, go to https://wiki.sidestore.io/guides/getting-started/#pairing-file", preferredStyle: .alert)
+            let dialogMessage = UIAlertController(title: "Pairing File", message: "Select the pairing file or select \"Help\" for help.", preferredStyle: .alert)
             
             // Create OK button with action handler
             let ok = UIAlertAction(title: "OK", style: .default, handler: { (action) -> Void in
@@ -174,7 +174,18 @@ final class LaunchViewController: RSTLaunchViewController, UIDocumentPickerDeleg
                 UserDefaults.standard.isPairingReset = false
              })
             
-            //Add OK button to a dialog message
+            //Add "help" button to take user to wiki
+            let wikiOption = UIAlertAction(title: "Help", style: .default) { (action) in
+                let wikiURL: String = "https://docs.sidestore.io/docs/getting-started/pairing-file"
+                if let url = URL(string: wikiURL) {
+                    UIApplication.shared.open(url)
+                }
+                sleep(2)
+                exit(0)
+            }
+            
+            //Add buttons to dialog message
+            dialogMessage.addAction(wikiOption)
             dialogMessage.addAction(ok)
 
             // Present Alert to


### PR DESCRIPTION
### Changes
- changes the intro pop up to have a button that opens the docs page for getting a pairing file rather than before where it was an unclickable plain text url. The app then closes so that the pop up appears next time they open the app.


https://github.com/user-attachments/assets/ebf7b286-cae1-4acd-8523-f0fa933c1547

