### PR TITLE
Fix for Refresh Operation causing renewal/install of provisioning profiles for removed app extensions

### DIFF
--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -112,6 +112,22 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             }
             
             installedApp.appExtensions = installedExtensions
+
+            // Remove stale "PlugIns" (Extensions) from currently installed App
+            if let installedAppExns = ALTApplication(fileURL: installedApp.fileURL)?.appExtensions {
+                let currentAppExns = Set(installedApp.appExtensions).map{ $0.bundleIdentifier }
+                let staleAppExns = installedAppExns.filter{ !currentAppExns.contains($0.bundleIdentifier) }
+                
+                for staleAppExn in staleAppExns {
+                    do {
+                        try FileManager.default.removeItem(at: staleAppExn.fileURL)
+                        print("InstallAppOperation.appExtensions: removed stale app-extension: \(staleAppExn.fileURL)")
+                    } catch {
+                        print("InstallAppOperation.appExtensions processing error Error: \(error)")
+                    }
+                }
+            }
+            
             
             self.context.beginInstallationHandler?(installedApp)
             


### PR DESCRIPTION
### Problem:
1. After the extensions are updated from resignedApp.appExtensions into in-memory installedApp.appExtensions instance and the DB, the same is not reflected in the disk.
2. This causes refresh() operation which looks for plugins(extensions) on the disk to pickup plugins that were already removed during installation to renew the provisioning profiles for these stale plugins eating up AppID.


### Fix Details:
1. updated InstalledAppOperation.swift to account for the updates to in-memory installedApp.appExtensions instance by removing/deleting those extensions on the disk.
2. updated AppManager.refresh() to stop refreshing when it detects that appExtensions in memory(or in DB) and disk are mismatching and log OperationError.


### TODO: 
1. Since refresh will now renew only installed appExtensions with this change, the user needs to do a fresh install of the same app to get prompt for the "choice of app extensions selection". Alternatively we can simulate this in the code by updating AppManger.refresh() to invoke removeAppExtensions() and provide the same prompt if refresh is invoked by user in a UI context. Or this can be added as context menu dropdown option with title "re-install" where the user doesn't need to have the IPA in hand.
2. Need to find the root cause or understand how the resignedApp is merged/replaced with the installedApp in InstallAppOperation.swift.


Fixes #706, fixes #696