### PR TITLE
Fix-regression: restored update-check logic(2a392dd) in InstalledApp.swift which was dropped in (1713fcc)

### DIFF
--- a/AltStoreCore/Model/InstalledApp.swift
+++ b/AltStoreCore/Model/InstalledApp.swift
@@ -163,8 +163,9 @@ public extension InstalledApp
     class func updatesFetchRequest() -> NSFetchRequest<InstalledApp>
     {
         let fetchRequest = InstalledApp.fetchRequest() as NSFetchRequest<InstalledApp>
-        fetchRequest.predicate = NSPredicate(format: "%K == YES AND %K != nil AND %K != %K",
-                                             #keyPath(InstalledApp.isActive), #keyPath(InstalledApp.storeApp), #keyPath(InstalledApp.version), #keyPath(InstalledApp.storeApp.latestSupportedVersion.version))
+        fetchRequest.predicate = NSPredicate(format: "%K == YES AND %K == YES",
+                                             #keyPath(InstalledApp.isActive), #keyPath(InstalledApp.hasUpdate))
+
         return fetchRequest
     }
     


### PR DESCRIPTION
Fixes #666, #698 

changes are self-explanatory as per title.