### PR TITLE
refresh-app: enhanced error logging when app exenstion validation check fails

### DIFF
--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -1427,10 +1427,11 @@ private extension AppManager
             let dbAppExNames = dbAppEx.map{ $0.bundleIdentifier }
                 
             let isMatching = Set(dbAppExNames) == Set(diskAppExNames)
-            print("AppManager.refresh: App Extensions in DB and Disk are matching: \(isMatching)")
-            print("AppManager.refresh: dbAppEx: \(dbAppExNames); diskAppEx: \(String(describing: diskAppExNames))")
+            let errMessage = "AppManager.refresh: App Extensions in DB and Disk are matching: \(isMatching)\n"
+                           + "AppManager.refresh: dbAppEx: \(dbAppExNames); diskAppEx: \(String(describing: diskAppExNames))\n"
+            print(errMessage)
             if(!isMatching){
-                completionHandler(.failure(OperationError.invalidParameters))
+                completionHandler(.failure(OperationError.refreshAppFailed(message: errMessage)))
             }
             op.finish()
         }

--- a/AltStore/Operations/OperationError.swift
+++ b/AltStore/Operations/OperationError.swift
@@ -35,6 +35,7 @@ extension OperationError
         case noSources
         case openAppFailed//(name: String)
         case missingAppGroup
+        case refreshAppFailed
 
         // Connection
         case noWiFi = 1200
@@ -107,6 +108,10 @@ extension OperationError
         OperationError(code: .anisetteV3Error, failureReason: message)
     }
 
+    static func refreshAppFailed(message: String) -> OperationError {
+        OperationError(code: .refreshAppFailed, failureReason: message)
+    }
+
 }
 
 
@@ -176,6 +181,11 @@ struct OperationError: ALTLocalizedError {
         case .anisetteV3Error: return NSLocalizedString("An error occurred when getting anisette data from a V3 server: %@. Please try again. If the issue persists, report it on GitHub Issues!", comment: "")
         case .cacheClearError: return NSLocalizedString("An error occurred while clearing cache: %@", comment: "")
         case .SideJITIssue: return NSLocalizedString("An error occurred while using SideJIT: %@", comment: "")
+            
+        case .refreshAppFailed:
+            let message = self._failureReason ?? ""
+            return String(format: NSLocalizedString("Unable to refresh App\n%@", comment: ""), message)
+
         }
     }
     


### PR DESCRIPTION
Changes:
1. Added new Error tag "refreshAppFailed" in OperationError.swift
2. updated AppManager.refresh() validateAppExtensionsOperation to use OperationError.refreshAppFailed() for enhanced error logging.