### PR TITLE
diagnostics: improved error logging for OperationError.invalidParameters

### DIFF
--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -1185,9 +1185,15 @@ private extension AppManager
                     return
                 }
 */
-                guard let extensions = context.app?.appExtensions else { throw OperationError.invalidParameters }
+                guard let extensions = context.app?.appExtensions else {
+                    throw OperationError.invalidParameters("AppManager._install.removeAppExtensionsOperation: context.app?.appExtensions is nil")
+                }
                 
-                guard let app = context.app, let presentingViewController = context.authenticatedContext.presentingViewController else { throw OperationError.invalidParameters }
+                guard let app = context.app,
+                      let presentingViewController = context.authenticatedContext.presentingViewController
+                else {
+                    throw OperationError.invalidParameters("AppManager._install.removeAppExtensionsOperation: context.app or context.authenticatedContext.presentingViewController is nil")
+                }
                 
                 
                 self?.removeAppExtensions(from: app, extensions: extensions, presentingViewController) { result in
@@ -1253,13 +1259,20 @@ private extension AppManager
                     throw error
                 }
                 
-                guard let profiles = context.provisioningProfiles else { throw OperationError.invalidParameters }
+                guard let profiles = context.provisioningProfiles else {
+                    throw OperationError.invalidParameters("AppManager._install.deactivateAppsOperation: context.provisioningProfiles is nil")
+                }
                 if !profiles.contains(where: { $1.isFreeProvisioningProfile == true }) {
                     operation.finish()
                     return
                 }
                                 
-                guard let app = context.app, let presentingViewController = context.authenticatedContext.presentingViewController else { throw OperationError.invalidParameters }
+                guard
+                    let app = context.app,
+                    let presentingViewController = context.authenticatedContext.presentingViewController
+                else {
+                    throw OperationError.invalidParameters("AppManager._install.deactivateAppsOperation: self.context.app or context.authenticatedContext.presentingViewController is nil")
+                }
                 
                 self?.deactivateApps(for: app, presentingViewController: presentingViewController) { result in
                     switch result
@@ -1298,7 +1311,9 @@ private extension AppManager
                     throw error
                 }
                 
-                guard let app = context.app else { throw OperationError.invalidParameters }
+                guard let app = context.app else {
+                    throw OperationError.invalidParameters("AppManager._install.patchAppOperation: context.app is nil")
+                }
                 
                 guard let isUntetherRequired = app.bundle.infoDictionary?[Bundle.Info.untetherRequired] as? Bool,
                       let minimumiOSVersionString = app.bundle.infoDictionary?[Bundle.Info.untetherMinimumiOSVersion] as? String,

--- a/AltStore/My Apps/MyAppsViewController.swift
+++ b/AltStore/My Apps/MyAppsViewController.swift
@@ -791,7 +791,9 @@ private extension MyAppsViewController
                     throw error
                 }
                 
-                guard let fileURL = context.fileURL else { throw OperationError.invalidParameters }
+                guard let fileURL = context.fileURL else {
+                    throw OperationError.invalidParameters("MyAppsViewController.sideloadApp.unzipAppOperation: context.fileURL is nil")
+                }
                 defer {
                     try? FileManager.default.removeItem(at: fileURL)
                 }
@@ -825,7 +827,9 @@ private extension MyAppsViewController
                     throw error
                 }
                 
-                guard let application = context.application else { throw OperationError.invalidParameters }
+                guard let application = context.application else {
+                    throw OperationError.invalidParameters("MyAppsViewController.sideloadApp.installAppOperation: context.application is nil")
+                }
                 
                 let group = AppManager.shared.install(application, presentingViewController: self) { (result) in
                     switch result

--- a/AltStore/Operations/BackupAppOperation.swift
+++ b/AltStore/Operations/BackupAppOperation.swift
@@ -48,7 +48,9 @@ class BackupAppOperation: ResultOperation<Void>
         {
             if let error = self.context.error { throw error }
             
-            guard let installedApp = self.context.installedApp, let context = installedApp.managedObjectContext else { throw OperationError.invalidParameters }
+            guard let installedApp = self.context.installedApp, let context = installedApp.managedObjectContext else {
+                throw OperationError.invalidParameters("BackupAppOperation.main: self.context.installedApp or installedApp.managedObjectContext is nil")
+            }
             context.perform {
                 do
                 {

--- a/AltStore/Operations/EnableJITOperation.swift
+++ b/AltStore/Operations/EnableJITOperation.swift
@@ -50,7 +50,9 @@ final class EnableJITOperation<Context: EnableJITContext>: ResultOperation<Void>
             return
         }
         
-        guard let installedApp = self.context.installedApp else { return self.finish(.failure(OperationError.invalidParameters)) }
+        guard let installedApp = self.context.installedApp else {
+            return self.finish(.failure(OperationError.invalidParameters("EnableJITOperation.main: self.context.installedApp is nil")))
+        }
         if #available(iOS 17, *) {
             let sideJITenabled = UserDefaults.standard.sidejitenable
             let SideJITIP = UserDefaults.standard.textInputSideJITServerurl ?? ""

--- a/AltStore/Operations/FetchAppIDsOperation.swift
+++ b/AltStore/Operations/FetchAppIDsOperation.swift
@@ -39,7 +39,9 @@ final class FetchAppIDsOperation: ResultOperation<([AppID], NSManagedObjectConte
         guard
             let team = self.context.team,
             let session = self.context.session
-        else { return self.finish(.failure(OperationError.invalidParameters)) }
+        else {
+            return self.finish(.failure(OperationError.invalidParameters("FetchAppIDsOperation.main: self.context.team or self.context.session is nil")))
+        }
                 
         ALTAppleAPI.shared.fetchAppIDs(for: team, session: session) { (appIDs, error) in
             self.managedObjectContext.perform {

--- a/AltStore/Operations/FetchProvisioningProfilesOperation.swift
+++ b/AltStore/Operations/FetchProvisioningProfilesOperation.swift
@@ -43,7 +43,8 @@ final class FetchProvisioningProfilesOperation: ResultOperation<[String: ALTProv
         guard
             let team = self.context.team,
             let session = self.context.session
-        else { return self.finish(.failure(OperationError.invalidParameters)) }
+        else {
+            return self.finish(.failure(OperationError.invalidParameters("FetchProvisioningProfilesOperation.main: self.context.team or self.context.session is nil"))) }
         
         guard let app = self.context.app else { return self.finish(.failure(OperationError.appNotFound(name: nil))) }
 

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -43,7 +43,9 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             let certificate = self.context.certificate,
             let resignedApp = self.context.resignedApp,
             let provisioningProfiles = self.context.provisioningProfiles
-        else { return self.finish(.failure(OperationError.invalidParameters)) }
+        else {
+            return self.finish(.failure(OperationError.invalidParameters("InstallAppOperation.main: self.context.certificate or self.context.resignedApp or self.context.provisioningProfiles is nil")))
+        }
         
         let backgroundContext = DatabaseManager.shared.persistentContainer.newBackgroundContext()
         backgroundContext.perform {

--- a/AltStore/Operations/OperationError.swift
+++ b/AltStore/Operations/OperationError.swift
@@ -56,7 +56,6 @@ extension OperationError
     static let notAuthenticated: OperationError = .init(code: .notAuthenticated)
     static let unknownUDID: OperationError = .init(code: .unknownUDID)
     static let invalidApp: OperationError = .init(code: .invalidApp)
-    static let invalidParameters: OperationError = .init(code: .invalidParameters)
     static let noSources: OperationError = .init(code: .noSources)
     static let missingAppGroup: OperationError = .init(code: .missingAppGroup)
 
@@ -112,6 +111,9 @@ extension OperationError
         OperationError(code: .refreshAppFailed, failureReason: message)
     }
 
+    static func invalidParameters(_ message: String? = nil) -> OperationError {
+        OperationError(code: .invalidParameters, failureReason: message)
+    }
 }
 
 
@@ -160,7 +162,6 @@ struct OperationError: ALTLocalizedError {
         case .notAuthenticated: return NSLocalizedString("You are not signed in.", comment: "")
         case .unknownUDID: return NSLocalizedString("SideStore could not determine this device's UDID.", comment: "")
         case .invalidApp: return NSLocalizedString("The app is in an invalid format.", comment: "")
-        case .invalidParameters: return NSLocalizedString("Invalid parameters.", comment: "")
         case .maximumAppIDLimitReached: return NSLocalizedString("Cannot register more than 10 App IDs within a 7 day period.", comment: "")
         case .noSources: return NSLocalizedString("There are no SideStore sources.", comment: "")
         case .missingAppGroup: return NSLocalizedString("SideStore's shared app group could not be accessed.", comment: "")
@@ -186,7 +187,11 @@ struct OperationError: ALTLocalizedError {
             let message = self._failureReason ?? ""
             return String(format: NSLocalizedString("Unable to refresh App\n%@", comment: ""), message)
 
+        case .invalidParameters:
+            let message = self._failureReason.map { ": \n\($0)" } ?? "."
+            return String(format: NSLocalizedString("Invalid parameters%@", comment: ""), message)
         }
+        
     }
     
     var recoverySuggestion: String? {

--- a/AltStore/Operations/Patch App/PatchAppOperation.swift
+++ b/AltStore/Operations/Patch App/PatchAppOperation.swift
@@ -98,7 +98,9 @@ final class PatchAppOperation: ResultOperation<Void>
             return
         }
         
-        guard let resignedApp = self.context.resignedApp else { return self.finish(.failure(OperationError.invalidParameters)) }
+        guard let resignedApp = self.context.resignedApp else {
+            return self.finish(.failure(OperationError.invalidParameters("PatchAppOperation.main: self.context.resignedApp is nil")))
+        }
         
         self.progressHandler?(self.progress, NSLocalizedString("Downloading iOS firmware...", comment: ""))
                 

--- a/AltStore/Operations/RefreshAppOperation.swift
+++ b/AltStore/Operations/RefreshAppOperation.swift
@@ -37,7 +37,10 @@ final class RefreshAppOperation: ResultOperation<InstalledApp>
         {
             if let error = self.context.error { return self.finish(.failure(error)) }
             
-            guard let profiles = self.context.provisioningProfiles else { return self.finish(.failure(OperationError.invalidParameters)) }
+            guard let profiles = self.context.provisioningProfiles else {
+                return self.finish(.failure(OperationError.invalidParameters("RefreshAppOperation.main: self.context.provisioningProfiles is nil")))
+            }
+            
             guard let app = self.context.app else { return self.finish(.failure(OperationError(.appNotFound(name: nil)))) }
 
             for p in profiles {

--- a/AltStore/Operations/RemoveAppBackupOperation.swift
+++ b/AltStore/Operations/RemoveAppBackupOperation.swift
@@ -35,7 +35,9 @@ final class RemoveAppBackupOperation: ResultOperation<Void>
             return
         }
         
-        guard let installedApp = self.context.installedApp else { return self.finish(.failure(OperationError.invalidParameters)) }
+        guard let installedApp = self.context.installedApp else {
+            return self.finish(.failure(OperationError.invalidParameters("RemoveAppBackupOperation.main: self.context.installedApp is nil")))
+        }
         installedApp.managedObjectContext?.perform {
             guard let backupDirectoryURL = FileManager.default.backupDirectoryURL(for: installedApp) else { return self.finish(.failure(OperationError.missingAppGroup)) }
             

--- a/AltStore/Operations/RemoveAppOperation.swift
+++ b/AltStore/Operations/RemoveAppOperation.swift
@@ -33,7 +33,9 @@ final class RemoveAppOperation: ResultOperation<InstalledApp>
             return
         }
         
-        guard let installedApp = self.context.installedApp else { return self.finish(.failure(OperationError.invalidParameters)) }
+        guard let installedApp = self.context.installedApp else {
+            return self.finish(.failure(OperationError.invalidParameters("RemoveAppOperation.main: self.context.installedApp is nil")))
+        }
         
         installedApp.managedObjectContext?.perform {
             let resignedBundleIdentifier = installedApp.resignedBundleIdentifier

--- a/AltStore/Operations/ResignAppOperation.swift
+++ b/AltStore/Operations/ResignAppOperation.swift
@@ -42,7 +42,12 @@ final class ResignAppOperation: ResultOperation<ALTApplication>
             let profiles = self.context.provisioningProfiles,
             let team = self.context.team,
             let certificate = self.context.certificate
-        else { return self.finish(.failure(OperationError.invalidParameters)) }
+        else {
+            return self.finish(.failure(OperationError.invalidParameters("ResignAppOperation.main: " +
+                                                                         "self.context.team or " +
+                                                                         "self.context.provisioningProfiles or" +
+                                                                         "self.context.certificate is nil")))
+        }
         
         // Prepare app bundle
         let prepareAppProgress = Progress.discreteProgress(totalUnitCount: 2)

--- a/AltStore/Operations/SendAppOperation.swift
+++ b/AltStore/Operations/SendAppOperation.swift
@@ -36,7 +36,9 @@ final class SendAppOperation: ResultOperation<()>
             return self.finish(.failure(error))
         }
         
-        guard let resignedApp = self.context.resignedApp else { return self.finish(.failure(OperationError.invalidParameters)) }
+        guard let resignedApp = self.context.resignedApp else {
+            return self.finish(.failure(OperationError.invalidParameters("SendAppOperation.main: self.resignedApp is nil")))
+        }
         
         // self.context.resignedApp.fileURL points to the app bundle, but we want the .ipa.
         let app = AnyApp(name: resignedApp.name, bundleIdentifier: self.context.bundleIdentifier, url: resignedApp.fileURL)

--- a/AltStore/Operations/VerifyAppOperation.swift
+++ b/AltStore/Operations/VerifyAppOperation.swift
@@ -117,7 +117,9 @@ final class VerifyAppOperation: ResultOperation<Void>
                 throw error
             }
             
-            guard let app = self.context.app else { throw OperationError.invalidParameters }
+            guard let app = self.context.app else {
+                throw OperationError.invalidParameters("VerifyAppOperation.main: self.context.app is nil")
+            }
             
             if !["ny.litritt.ignited", "com.litritt.ignited"].contains(where: { $0 == app.bundleIdentifier }) {
                 guard app.bundleIdentifier == self.context.bundleIdentifier else {


### PR DESCRIPTION
### Diagnostics for Background Refresh and Shortcut issues #723 
- Added reason for erroring out with OperationError.InvalidParameters to further diagnose the refresh issue.


#### NOTE: This is NOT a fix but is for diagnostics.