### PR TITLE
Add missing = sign

### DIFF
--- a/AltStore/Extensions/ProcessInfo+SideStore.swift
+++ b/AltStore/Extensions/ProcessInfo+SideStore.swift
@@ -90,7 +90,7 @@ extension ProcessInfo {
         else if operatingSystemVersion >= OperatingSystemVersion(majorVersion: 18, minorVersion: 1, patchVersion: 0),
                 let currentBuild = BuildVersion(operatingSystemBuild),
                 let targetBuild  = BuildVersion("22B5054e") {
-            currentBuild > targetBuild
+            currentBuild >= targetBuild
         } else { false }
     }
 }


### PR DESCRIPTION
### Changes

- Current check for sparserestore is based on currentBuild > targetBuild
- Issue: targetBuild is 18.1b5, and 18.1b5 is not greater than 18.1b5
- Solution: add an equal sign to the check

Note that this doesn't fix the check for 17.7.1 and later 17.x versions.
