### PR TITLE
Partial-Fix for #723: Error on refresh operation must be set on self.context instead of group.context

### DIFF
--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -1207,7 +1207,7 @@ private extension AppManager
             }
             catch
             {
-                group.context.error = error
+                context.error = error
                 operation.finish()
             }
         }


### PR DESCRIPTION
### Issue #723:
- Error when refreshing one of the apps sets the error for group context thereby creating same error signature for all.
- This is misleading since the other apps could have proceeded with refresh but due to this "All or nothing" those refresh requests are also ignored BUT MARKED AS SAME ERROR.


### Fix (Changes):
- set error only to current AppOperationContext and not the group.context.
- This will enable other refreshable apps to proceed without being interrupted.

NOTE: Since SideStore intentionally takes install path even for refresh request, the removeAppExtensions operation still requires UI context, this bug will be fixed in next PR.