### PR TITLE
Fix: update sign-in screen toast text color to be primary color

### DIFF
--- a/AltStore/Authentication/AuthenticationViewController.swift
+++ b/AltStore/Authentication/AuthenticationViewController.swift
@@ -112,6 +112,8 @@ private extension AuthenticationViewController
 
                     let toastView = ToastView(error: error)
                     toastView.show(in: self)
+                    toastView.textLabel.textColor = .altPrimary
+                    toastView.detailTextLabel.textColor = .altPrimary
                     self.toastView = toastView
                     
                     self.signInButton.isIndicatingActivity = false


### PR DESCRIPTION
### Changes
- updated Error Toast to use .altPrimary color which is proper since primary and accent color is inverted in settings screen.