### PR TITLE
- Fix: DatabaseManager.migrateDatabaseToAppGroupIfNeeded() src and dest for replaceAt() cannot be same

### DIFF
--- a/AltStoreCore/Model/DatabaseManager.swift
+++ b/AltStoreCore/Model/DatabaseManager.swift
@@ -407,7 +407,10 @@ private extension DatabaseManager
                 // Migrate apps
                 if FileManager.default.fileExists(atPath: previousAppsDirectoryURL.path, isDirectory: nil)
                 {
-                    _ = try FileManager.default.replaceItemAt(appsDirectoryURL, withItemAt: previousAppsDirectoryURL)
+                    if(previousAppsDirectoryURL.path != appsDirectoryURL.path)
+                    {
+                        _ = try FileManager.default.replaceItemAt(appsDirectoryURL, withItemAt: previousAppsDirectoryURL)
+                    }
                 }
                 
                 finish(.success(()))


### PR DESCRIPTION
…st for replaceAt() cannot be same

### Changes
- added check to see src and dest are not same, before performing replaceAt

### Fix:
- fixes crash causing NSCocoaErrorDomainCode=512

fixes #316