### PR TITLE
-[Feature]: client-side: Anisette server fallback impl when current server is unreachable

### DIFF
--- a/AltStore/Settings/AnisetteServerList.swift
+++ b/AltStore/Settings/AnisetteServerList.swift
@@ -48,6 +48,8 @@ class AnisetteViewModel: ObservableObject {
                     let servers = try decoder.decode(AnisetteServerData.self, from: data)
                     DispatchQueue.main.async {
                         self.servers = servers.servers
+                        // store server addresses as list
+                        UserDefaults.standard.menuAnisetteServersList = servers.servers.map(\.self.address)
                     }
                 } catch {
                     // Handle decoding error

--- a/AltStoreCore/Extensions/UserDefaults+AltStore.swift
+++ b/AltStoreCore/Extensions/UserDefaults+AltStore.swift
@@ -28,6 +28,7 @@ public extension UserDefaults
     @NSManaged var customAnisetteURL: String?
     @NSManaged var menuAnisetteURL: String
     @NSManaged var menuAnisetteList: String
+    @NSManaged var menuAnisetteServersList: [String]
     @NSManaged var preferredServerID: String?
     
     @NSManaged var isBackgroundRefreshEnabled: Bool


### PR DESCRIPTION
### Changes
1. capture the decoded server list in UserDefaults.standard.menuAnisetteServersList (new variable)
2. ping current server for reachability (expected response code: 200-299 range)
3. traverse servers list (excluding current since it was already processed) to get next reachable server
4. use and make this server as current by setting UserDefaults.standard.menuAnisetteUrl.


### TODO:
1. Though this provides seamless fallback, the user might be annoyed that the server is switching randomly without external input in settings screen. (Need to think if we could make this switch temporary and restore user's selection after the selected server is reachable again).
=> Basically prevent surprises for (say) users who explicitly need only their servers!!
For this, the user could actually remove all unnecessary servers if they really require exclusivity though.
2. make Toast(popup message to user) about server unavailability and switching to new server.