### PR TITLE
- Fix: AnisetteServers: refresh server request shouldn't use local cache to get proper updates

### DIFF
--- a/AltStore/Settings/AnisetteServerList.swift
+++ b/AltStore/Settings/AnisetteServerList.swift
@@ -38,7 +38,12 @@ class AnisetteViewModel: ObservableObject {
     
     func getListOfServers() {
         guard let url = URL(string: source) else { return }
-        URLSession.shared.dataTask(with: url) { data, response, error in
+        
+        // DO NOT use local cache when fetching anisette servers
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        
+        URLSession.shared.dataTask(with: request) { data, response, error in
             if let error = error {
                 return
             }


### PR DESCRIPTION
### Changes
- Refresh Servers was not updating the anisette servers list on the client side, hence disabled local caching before performing url fetch request.
