### PR TITLE
[fetch-prebuilt.sh] - retain checked-in files from minimuxer repo

### DIFF
--- a/Dependencies/fetch-prebuilt.sh
+++ b/Dependencies/fetch-prebuilt.sh
@@ -67,7 +67,9 @@ check_for_update() {
                 echo "Unzipping generated.zip"
                 cd "$1"
                 unzip ./generated.zip
-                mv -v generated/* .
+                cp -v generated/* .
+                # Remove all files except ones that comes checked-in from minimuxer repository
+                find generated -type f ! -name 'minimuxer-Bridging-Header.h' ! -name 'minimuxer-helpers.swift' -exec rm -v {} \;
                 rm generated.zip
                 rmdir generated/
                 cd ..


### PR DESCRIPTION
- when minimuxer repo is cloned locally, these files get deleted by fetch-prebuilt.sh during cleanup of generated files marking changes in git.