### PR TITLE
[Refresh]: Remove install stuffs from refresh since in refresh should only renew provisioning profiles

### DIFF
--- a/AltStore/My Apps/MyAppsViewController.swift
+++ b/AltStore/My Apps/MyAppsViewController.swift
@@ -1151,7 +1151,9 @@ private extension MyAppsViewController
     
     func refresh(_ installedApp: InstalledApp)
     {
-        guard minimuxerStatus else { return }
+       // we do need minimuxer, coz it needs to talk to misagent daemon which manages profiles 
+       // so basically loopback vpn is still required
+       guard minimuxerStatus else { return }     // we don't need minimuxer when renewing appIDs only do we, heck we can even do it on mobile internet
 
         let previousProgress = AppManager.shared.refreshProgress(for: installedApp)
         guard previousProgress == nil else {
@@ -1467,7 +1469,10 @@ private extension MyAppsViewController
             do
             {
                 let tempApp = context.object(with: installedApp.objectID) as! InstalledApp
-                tempApp.needsResign = true
+                tempApp.needsResign = true                      // why do we want to resign it during refresh ?!!!!
+                                                                // I see now, so here we just mark that icon needs to be changed but leave it for refresh/install to do it
+                                                                // this is bad, coz now the weight of installing goes to refresh step !!! which is not what we want
+                
                 tempApp.hasAlternateIcon = (image != nil)
                 
                 if let image = image

--- a/AltStore/Settings/OperationsLoggingContolView.swift
+++ b/AltStore/Settings/OperationsLoggingContolView.swift
@@ -77,10 +77,10 @@ struct OperationsLoggingControlView: View {
                                 }
                             ))
                             
-                            CustomToggle("7. FetchProvisioningProfiles", isOn: Binding(
-                                get: { self.viewModel.getFromDatabase(for: FetchProvisioningProfilesOperation.self) },
+                            CustomToggle("7. FetchProvisioningProfiles(I)", isOn: Binding(
+                                get: { self.viewModel.getFromDatabase(for: FetchProvisioningProfilesInstallOperation.self) },
                                 set: { value in
-                                    self.viewModel.updateDatabase(for: FetchProvisioningProfilesOperation.self, value: value)
+                                    self.viewModel.updateDatabase(for: FetchProvisioningProfilesInstallOperation.self, value: value)
                                 }
                             ))
                             
@@ -108,7 +108,14 @@ struct OperationsLoggingControlView: View {
                         
                         CustomSection(header: Text("Refresh Operations"))
                         {
-                            CustomToggle("1. RefreshApp", isOn: Binding(
+                            CustomToggle("1. FetchProvisioningProfiles(R)", isOn: Binding(
+                                get: { self.viewModel.getFromDatabase(for: FetchProvisioningProfilesRefreshOperation.self) },
+                                set: { value in
+                                    self.viewModel.updateDatabase(for: FetchProvisioningProfilesRefreshOperation.self, value: value)
+                                }
+                            ))
+
+                            CustomToggle("2. RefreshApp", isOn: Binding(
                                 get: { self.viewModel.getFromDatabase(for: RefreshAppOperation.self) },
                                 set: { value in
                                     self.viewModel.updateDatabase(for: RefreshAppOperation.self, value: value)


### PR DESCRIPTION
### Changes
- commented all install related code (which was used for reinstalling sidestore at end of refresh)
- Need beta testers for both paid and free account testers 
- Suspecting if something that had to do with tampering the app-bundle expecting a re-install of sidestore then it would be broken now (and this is fine, coz we need separation of concerns anyway, so we can fix such issues once someone reports it)
- One example is, changing appIcon, i think current implementation marks icon is changed and it is updated when reinstalling, but these are non-issues (ie not major ones)


<!-- Fill this list with what your PR changes. Example: -->
- Fix shortcut refresh not working bug

<!-- If your PR is ready to be merged, you can remove this section. -->
### Todo before merge

<!-- Example: -->
- [x] Finish beta testing for 7 days free accts 
- [ ] Test
