### PR TITLE
[Settings]: Fix: DisableAppLimit switch reverting back to off state even if on iOS where sparseRestore is not patched yet

### DIFF
--- a/AltStore.xcodeproj/project.pbxproj
+++ b/AltStore.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		03F06CD52942C27E001C4D68 /* Bundle+AltStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E314122A05D4C00370A3C /* Bundle+AltStore.swift */; };
 		0E05025C2BEC947000879B5C /* String+SideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E05025B2BEC947000879B5C /* String+SideStore.swift */; };
-		0E13E5862CC8F55900E9C0DF /* ProcessInfo+SideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E13E5852CC8F55900E9C0DF /* ProcessInfo+SideStore.swift */; };
 		0E1A1F912AE36A9700364CAD /* bytearray.c in Sources */ = {isa = PBXBuildFile; fileRef = 0E1A1F902AE36A9600364CAD /* bytearray.c */; };
 		0EA1665B2ADFE0D2003015C1 /* out-limd.c in Sources */ = {isa = PBXBuildFile; fileRef = 0EA166472ADFE0D1003015C1 /* out-limd.c */; };
 		0EA1665C2ADFE0D2003015C1 /* out-default.c in Sources */ = {isa = PBXBuildFile; fileRef = 0EA166522ADFE0D2003015C1 /* out-default.c */; };
@@ -87,6 +86,7 @@
 		A8C6D5172D1EE95B00DF01F1 /* OpenSSL.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A859ED5B2D1EE80D003DCC58 /* OpenSSL.xcframework */; };
 		A8C6D5182D1EE95B00DF01F1 /* OpenSSL.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A859ED5B2D1EE80D003DCC58 /* OpenSSL.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A8D484D82D0CD306002C691D /* AltBackup.ipa in Resources */ = {isa = PBXBuildFile; fileRef = A8D484D72D0CD306002C691D /* AltBackup.ipa */; };
+		A8D49F532D3D2F9400844B92 /* ProcessInfo+AltStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8D49F522D3D2F9400844B92 /* ProcessInfo+AltStore.swift */; };
 		A8F838922D048E8F00ED425D /* libEmotionalDamage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19104DB22909C06C00C49C7B /* libEmotionalDamage.a */; };
 		A8F838932D048E8F00ED425D /* libminimuxer.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 191E5FAB290A5D92001A3B7C /* libminimuxer.a */; };
 		A8F838942D048ECE00ED425D /* libimobiledevice.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BF45872B2298D31600BD7491 /* libimobiledevice.a */; };
@@ -574,9 +574,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0E0502592BEC83C500879B5C /* OperatingSystemVersion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Comparable.swift"; sourceTree = "<group>"; };
 		0E05025B2BEC947000879B5C /* String+SideStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SideStore.swift"; sourceTree = "<group>"; };
-		0E13E5852CC8F55900E9C0DF /* ProcessInfo+SideStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+SideStore.swift"; sourceTree = "<group>"; };
 		0E1A1F902AE36A9600364CAD /* bytearray.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = bytearray.c; path = src/bytearray.c; sourceTree = "<group>"; };
 		0EA166412ADFE0D1003015C1 /* jplist.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jplist.c; path = Dependencies/libplist/src/jplist.c; sourceTree = SOURCE_ROOT; };
 		0EA166422ADFE0D1003015C1 /* Date.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Date.cpp; path = Dependencies/libplist/src/Date.cpp; sourceTree = SOURCE_ROOT; };
@@ -663,6 +661,7 @@
 		A8C38C312D206B2500E83DBD /* FileOutputStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOutputStream.swift; sourceTree = "<group>"; };
 		A8C38C372D2084D000E83DBD /* ConsoleLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleLogView.swift; sourceTree = "<group>"; };
 		A8D484D72D0CD306002C691D /* AltBackup.ipa */ = {isa = PBXFileReference; lastKnownFileType = file; path = AltBackup.ipa; sourceTree = "<group>"; };
+		A8D49F522D3D2F9400844B92 /* ProcessInfo+AltStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+AltStore.swift"; sourceTree = "<group>"; };
 		A8F66C3C2D04D433009689E6 /* em_proxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = em_proxy.h; sourceTree = "<group>"; };
 		A8F66C602D04D464009689E6 /* minimuxer.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = minimuxer.xcodeproj; sourceTree = "<group>"; };
 		A8FD915B2D046EF100322782 /* ProcessError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessError.swift; sourceTree = "<group>"; };
@@ -1720,12 +1719,12 @@
 				BF66EEE62501AED0007EE018 /* UIColor+Hex.swift */,
 				BF66EEE42501AED0007EE018 /* UserDefaults+AltStore.swift */,
 				BF6A531F246DC1B0004F59C8 /* FileManager+SharedDirectories.swift */,
-				0E0502592BEC83C500879B5C /* OperatingSystemVersion+Comparable.swift */,
 				0E05025B2BEC947000879B5C /* String+SideStore.swift */,
 				D5F48B4729CCF21B002B52A4 /* AltStore+Async.swift */,
 				D5893F7E2A14183200E767CD /* NSManagedObjectContext+Conveniences.swift */,
 				D52A2F962ACB40F700BDF8E3 /* Logger+AltStore.swift */,
 				D56915052AD5D75B00A2B747 /* Regex+Permissions.swift */,
+				A8D49F522D3D2F9400844B92 /* ProcessInfo+AltStore.swift */,
 				D5B6F6A82AD75D01007EED5A /* ProcessInfo+Previews.swift */,
 				D552EB052AF453F900A3AB4D /* URL+Normalized.swift */,
 			);
@@ -1996,7 +1995,6 @@
 				BFE00A1F2503097F00EB4D0C /* INInteraction+AltStore.swift */,
 				D57F2C9326E01BC700B9FA39 /* UIDevice+Vibration.swift */,
 				B376FE3D29258C8900E18883 /* OSLog+SideStore.swift */,
-				0E13E5852CC8F55900E9C0DF /* ProcessInfo+SideStore.swift */,
 				D5927D6529DCC89000D6898E /* UINavigationBarAppearance+TintColor.swift */,
 				D54058BA2A1D8FE3008CCC58 /* UIColor+AltStore.swift */,
 				D5FB28EB2ADDF68D00A1C337 /* UIFontDescriptor+Bold.swift */,
@@ -2867,6 +2865,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A8D49F532D3D2F9400844B92 /* ProcessInfo+AltStore.swift in Sources */,
 				A82067842D03DC0600645C0D /* OperatingSystemVersion+Comparable.swift in Sources */,
 				D5FB28EE2ADDF89800A1C337 /* KnownSource.swift in Sources */,
 				BF66EED32501AECA007EE018 /* AltStore2ToAltStore3.xcmappingmodel in Sources */,
@@ -3076,7 +3075,6 @@
 				BF08858522DE7EC800DE9F1E /* UpdateCollectionViewCell.swift in Sources */,
 				BF770E5822BC3D0F002A40FE /* RefreshGroup.swift in Sources */,
 				19B9B7452845E6DF0076EF69 /* SelectTeamViewController.swift in Sources */,
-				0E13E5862CC8F55900E9C0DF /* ProcessInfo+SideStore.swift in Sources */,
 				A88B8C492D35AD3200F53F9D /* OperationsLoggingContolView.swift in Sources */,
 				D59162AB29BA60A9005CBF47 /* SourceHeaderView.swift in Sources */,
 				BF18B0F122E25DF9005C4CF5 /* ToastView.swift in Sources */,

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -44,7 +44,10 @@ extension SettingsViewController
             var c: [AppRefreshRow] = [.backgroundRefresh, .noIdleTimeout, .addToSiri]
 
             // conditional entries go at the last to preserve ordering
-            if !ProcessInfo().sparseRestorePatched { c.append(.disableAppLimit) }
+            if UserDefaults.standard.isCowExploitSupported || !ProcessInfo().sparseRestorePatched
+            {
+                c.append(.disableAppLimit)
+            }
             return c
         }
     }
@@ -477,13 +480,16 @@ private extension SettingsViewController
     }
     
     @IBAction func toggleDisableAppLimit(_ sender: UISwitch) {
-        UserDefaults.standard.isAppLimitDisabled = sender.isOn
-        
-        // TODO: Here we force reload the activeAppsLimit after detecting change in isAppLimitDisabled
-        //       Why do we need to do this, once identified if this is intentional and working as expected, remove this todo
-        if UserDefaults.standard.activeAppsLimit != nil
-        {
-            UserDefaults.standard.activeAppsLimit = InstalledApp.freeAccountActiveAppsLimit
+        if UserDefaults.standard.isCowExploitSupported || !ProcessInfo().sparseRestorePatched {
+            // accept state change only when valid
+            UserDefaults.standard.isAppLimitDisabled = sender.isOn
+            
+            // TODO: Here we force reload the activeAppsLimit after detecting change in isAppLimitDisabled
+            //       Why do we need to do this, once identified if this is intentional and working as expected, remove this todo
+            if UserDefaults.standard.activeAppsLimit != nil
+            {
+                UserDefaults.standard.activeAppsLimit = InstalledApp.freeAccountActiveAppsLimit
+            }
         }
     }
     

--- a/AltStoreCore/Extensions/ProcessInfo+AltStore.swift
+++ b/AltStoreCore/Extensions/ProcessInfo+AltStore.swift
@@ -71,20 +71,20 @@ fileprivate struct BuildVersion: Comparable {
 }
 
 extension ProcessInfo {
-    var shortVersion: String {
+    public var shortVersion: String {
         operatingSystemVersionString
             .replacingOccurrences(of: "Version ", with: "")
             .replacingOccurrences(of: "Build ", with: "")
     }
     
-    var operatingSystemBuild: String {
+    public var operatingSystemBuild: String {
         if let start = shortVersion.range(of: "(")?.upperBound,
            let end = shortVersion.range(of: ")")?.lowerBound {
             shortVersion[start..<end].replacingOccurrences(of: "Build ", with: "")
         } else { "???" }
     }
     
-    var sparseRestorePatched: Bool {
+    public var sparseRestorePatched: Bool {
         if operatingSystemVersion < OperatingSystemVersion(majorVersion: 18, minorVersion: 1, patchVersion: 0) { false }
         else if operatingSystemVersion > OperatingSystemVersion(majorVersion: 18, minorVersion: 1, patchVersion: 1) { true }
         else if operatingSystemVersion >= OperatingSystemVersion(majorVersion: 18, minorVersion: 1, patchVersion: 0),

--- a/AltStoreCore/Extensions/UserDefaults+AltStore.swift
+++ b/AltStoreCore/Extensions/UserDefaults+AltStore.swift
@@ -143,7 +143,8 @@ public extension UserDefaults
         UserDefaults.standard.register(defaults: defaults)
         UserDefaults.shared.register(defaults: defaults)
         
-        if !isMacDirtyCowSupported
+        // MDC is unsupported and spareRestore is patched
+        if !isMacDirtyCowSupported && ProcessInfo().sparseRestorePatched
         {
             // Disable isAppLimitDisabled if running iOS version that doesn't support MacDirtyCow.
             UserDefaults.standard.isAppLimitDisabled = false


### PR DESCRIPTION
### Changes
- added checks for SparseRestore in addition to MDC check before disabling the value in db.
- made the Disable App Limit switch to ignore toggles when it is on unsupported iOS version.

Fixes #847 