### PR TITLE
Cellular Automation

### DIFF
--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -954,6 +954,11 @@ extension AppManager
         context.resignedApp = resignedApp
         
         let patchAppOperation = PatchAppOperation(context: context)
+        
+        let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
+        let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
+
+        UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
         let sendAppOperation = SendAppOperation(context: context)
         let installOperation = InstallAppOperation(context: context)
         
@@ -993,6 +998,7 @@ extension AppManager
             case .failure(let error): completionHandler(.failure(error))
             case .success(let installedApp): completionHandler(.success(installedApp))
             }
+            UIApplication.shared.open(shortcutURLon, options: [:], completionHandler: nil)
         }
         installOperation.addDependency(sendAppOperation)
         

--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -959,10 +959,6 @@ extension AppManager
         
         let installationProgress = Progress.discreteProgress(totalUnitCount: 100)
         installationProgress.addChild(sendAppOperation.progress, withPendingUnitCount: 40)
-        let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
-        let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
-
-        UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
         installationProgress.addChild(installOperation.progress, withPendingUnitCount: 60)
         
         /* Patch */

--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -954,11 +954,12 @@ extension AppManager
         context.resignedApp = resignedApp
         
         let patchAppOperation = PatchAppOperation(context: context)
-        
+        /*
         let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
         let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
 
         UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
+         */
         let sendAppOperation = SendAppOperation(context: context)
         let installOperation = InstallAppOperation(context: context)
         
@@ -998,7 +999,7 @@ extension AppManager
             case .failure(let error): completionHandler(.failure(error))
             case .success(let installedApp): completionHandler(.success(installedApp))
             }
-            UIApplication.shared.open(shortcutURLon, options: [:], completionHandler: nil)
+            //UIApplication.shared.open(shortcutURLon, options: [:], completionHandler: nil)
         }
         installOperation.addDependency(sendAppOperation)
         

--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -953,16 +953,16 @@ extension AppManager
         let context = Context(bundleIdentifier: originalBundleID, authenticatedContext: authContext)
         context.resignedApp = resignedApp
         
-        let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
-        let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
-
-        UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
         let patchAppOperation = PatchAppOperation(context: context)
         let sendAppOperation = SendAppOperation(context: context)
         let installOperation = InstallAppOperation(context: context)
         
         let installationProgress = Progress.discreteProgress(totalUnitCount: 100)
         installationProgress.addChild(sendAppOperation.progress, withPendingUnitCount: 40)
+        let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
+        let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
+
+        UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
         installationProgress.addChild(installOperation.progress, withPendingUnitCount: 60)
         
         /* Patch */

--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -953,13 +953,11 @@ extension AppManager
         let context = Context(bundleIdentifier: originalBundleID, authenticatedContext: authContext)
         context.resignedApp = resignedApp
         
-        let patchAppOperation = PatchAppOperation(context: context)
-        /*
         let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
         let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
 
         UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
-         */
+        let patchAppOperation = PatchAppOperation(context: context)
         let sendAppOperation = SendAppOperation(context: context)
         let installOperation = InstallAppOperation(context: context)
         

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -225,7 +225,9 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             }
             
             do {
-                UIApplication.shared.open("shortcuts://run-shortcut?name=TurnOffData", completionHandler: nil)
+                if let url = URL(string: "shortcuts://run-shortcut?name=TurnOffData") {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                }
                 try install_ipa(installedApp.bundleIdentifier)
                 installing = false
                 installedApp.refreshedDate = Date()

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -225,6 +225,7 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             }
             
             do {
+                UIApplication.shared.open("shortcuts://run-shortcut?name=TurnOffData", completionHandler: nil)
                 try install_ipa(installedApp.bundleIdentifier)
                 installing = false
                 installedApp.refreshedDate = Date()

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -225,9 +225,9 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             }
             
             do {
-                if let url = URL(string: "shortcuts://run-shortcut?name=TurnOffData") {
-                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
-                }
+                let shortcutURL = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
+
+                UIApplication.shared.open(shortcutURL, options: [:], completionHandler: nil)
                 try install_ipa(installedApp.bundleIdentifier)
                 installing = false
                 installedApp.refreshedDate = Date()

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -225,9 +225,6 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             }
             
             do {
-                let shortcutURL = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
-
-                UIApplication.shared.open(shortcutURL, options: [:], completionHandler: nil)
                 try install_ipa(installedApp.bundleIdentifier)
                 installing = false
                 installedApp.refreshedDate = Date()

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -13,6 +13,8 @@ import AltSign
 import Roxas
 import minimuxer
 
+let shortcutURLonDelay = URL(string: "shortcuts://run-shortcut?name=TurnOnDataDelay")!
+
 @objc(InstallAppOperation)
 final class InstallAppOperation: ResultOperation<InstalledApp>
 {
@@ -204,6 +206,10 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
                             let alert = UIAlertController(title: "Finish Refresh", message: "Please reopen SideStore after the process is finished.To finish refreshing, SideStore must be moved to the background. To do this, you can either go to the Home Screen manually or by hitting Continue. Please reopen SideStore after doing this.", preferredStyle: .alert)
                             alert.addAction(UIAlertAction(title: NSLocalizedString("Continue", comment: ""), style: .default, handler: { _ in
                                 print("Going home")
+                                // Cell Shortcut
+                                UIApplication.shared.open(shortcutURLonDelay, options: [:]) { _ in
+                                    print("Cell OFF Shortcut finished execution.")}
+                                    
                                 UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
                             }))
 
@@ -220,6 +226,8 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
                             }
                         }
                     }
+                    // Cell Shortcut
+                    UIApplication.shared.open(shortcutURLonDelay, options: [:]) { _ in print("Cell OFF Shortcut finished execution.")}
                     UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
                 }
             }

--- a/AltStore/Operations/Patch App/PatchAppOperation.swift
+++ b/AltStore/Operations/Patch App/PatchAppOperation.swift
@@ -212,10 +212,6 @@ private extension PatchAppOperation
             #if targetEnvironment(simulator)
             throw PatchAppError.unsupportedOperatingSystemVersion(ProcessInfo.processInfo.operatingSystemVersion)
             #else
-            let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
-            let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
-
-            UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
             let spotlightPath = "Applications/Spotlight.app/Spotlight"
             let spotlightFileURL = self.patchDirectory.appendingPathComponent(spotlightPath)
             

--- a/AltStore/Operations/Patch App/PatchAppOperation.swift
+++ b/AltStore/Operations/Patch App/PatchAppOperation.swift
@@ -212,7 +212,10 @@ private extension PatchAppOperation
             #if targetEnvironment(simulator)
             throw PatchAppError.unsupportedOperatingSystemVersion(ProcessInfo.processInfo.operatingSystemVersion)
             #else
-            
+            let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
+            let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
+
+            UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
             let spotlightPath = "Applications/Spotlight.app/Spotlight"
             let spotlightFileURL = self.patchDirectory.appendingPathComponent(spotlightPath)
             

--- a/AltStore/Operations/SendAppOperation.swift
+++ b/AltStore/Operations/SendAppOperation.swift
@@ -39,7 +39,6 @@ final class SendAppOperation: ResultOperation<()>
         }
 
         let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
-        let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
 
         let app = AnyApp(name: resignedApp.name, bundleIdentifier: self.context.bundleIdentifier, url: resignedApp.fileURL, storeApp: nil)
         let fileURL = InstalledApp.refreshedIPAURL(for: app)

--- a/AltStore/Operations/SendAppOperation.swift
+++ b/AltStore/Operations/SendAppOperation.swift
@@ -27,43 +27,49 @@ final class SendAppOperation: ResultOperation<()>
         self.progress.totalUnitCount = 1
     }
     
-    override func main()
-    {
+    override func main() {
         super.main()
-        
-        if let error = self.context.error
-        {
+
+        if let error = self.context.error {
             return self.finish(.failure(error))
         }
-        
+
         guard let resignedApp = self.context.resignedApp else {
             return self.finish(.failure(OperationError.invalidParameters("SendAppOperation.main: self.resignedApp is nil")))
         }
-                
-        // self.context.resignedApp.fileURL points to the app bundle, but we want the .ipa.
+
         let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
         let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
 
-        UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
-        
         let app = AnyApp(name: resignedApp.name, bundleIdentifier: self.context.bundleIdentifier, url: resignedApp.fileURL, storeApp: nil)
         let fileURL = InstalledApp.refreshedIPAURL(for: app)
         print("AFC App `fileURL`: \(fileURL.absoluteString)")
-        
-        if let data = NSData(contentsOf: fileURL) {
-            do {
-                let bytes = Data(data).toRustByteSlice()
-                try yeet_app_afc(app.bundleIdentifier, bytes.forRust())
-                self.progress.completedUnitCount += 1
-                self.finish(.success(()))
-            } catch {
-                self.finish(.failure(MinimuxerError.RwAfc))
-                self.progress.completedUnitCount += 1
-                self.finish(.success(()))
+
+        // Wait for Shortcut to Finish Before Proceeding
+        UIApplication.shared.open(shortcutURLoff, options: [:]) { _ in
+            print("Shortcut finished execution. Proceeding with file transfer.")
+
+            DispatchQueue.global().async {
+                self.processFile(at: fileURL, for: app.bundleIdentifier)
             }
-        } else {
+        }
+    }
+
+    private func processFile(at fileURL: URL, for bundleIdentifier: String) {
+        guard let data = NSData(contentsOf: fileURL) else {
             print("IPA doesn't exist????")
-            self.finish(.failure(OperationError(.appNotFound(name: resignedApp.name))))
+            return self.finish(.failure(OperationError(.appNotFound(name: bundleIdentifier))))
+        }
+
+        do {
+            let bytes = Data(data).toRustByteSlice()
+            try yeet_app_afc(bundleIdentifier, bytes.forRust())
+            self.progress.completedUnitCount += 1
+            self.finish(.success(()))
+        } catch {
+            self.finish(.failure(MinimuxerError.RwAfc))
+            self.progress.completedUnitCount += 1
+            self.finish(.success(()))
         }
     }
 }

--- a/AltStore/Operations/SendAppOperation.swift
+++ b/AltStore/Operations/SendAppOperation.swift
@@ -41,9 +41,13 @@ final class SendAppOperation: ResultOperation<()>
         }
                 
         // self.context.resignedApp.fileURL points to the app bundle, but we want the .ipa.
+        let shortcutURLoff = URL(string: "shortcuts://run-shortcut?name=TurnOffData")!
+        let shortcutURLon = URL(string: "shortcuts://run-shortcut?name=TurnOnData")!
+
+        UIApplication.shared.open(shortcutURLoff, options: [:], completionHandler: nil)
+        
         let app = AnyApp(name: resignedApp.name, bundleIdentifier: self.context.bundleIdentifier, url: resignedApp.fileURL, storeApp: nil)
         let fileURL = InstalledApp.refreshedIPAURL(for: app)
-        
         print("AFC App `fileURL`: \(fileURL.absoluteString)")
         
         if let data = NSData(contentsOf: fileURL) {


### PR DESCRIPTION
This Pull request will allow automatic deactivation and activation of Cellular data to install apps via cell or enable jit over cell. 

**This PR is currently a draft and should not be merged atm.**

- [x] Auto disable cell properly
- [ ] Disable WiFi check when using cell automation
- [ ] Re-establish WiFi when done when refreshing SideStore or other apps (might require 2 different shortcuts)
- [ ] Add jit support (Below iOS 17)
- [ ] Setup process when enabling Cellular Automation