### PR TITLE
Add export certificate feature

### DIFF
--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -26,10 +26,12 @@ extension AppDelegate
     static let addSourceDeepLinkNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".AddSourceDeepLinkNotification")
     
     static let appBackupDidFinish = Notification.Name(Bundle.Info.appbundleIdentifier + ".AppBackupDidFinish")
+    static let exportCertificateNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".ExportCertificateNotification")
     
     static let importAppDeepLinkURLKey = "fileURL"
     static let appBackupResultKey = "result"
     static let addSourceDeepLinkURLKey = "sourceURL"
+    static let exportCertificateCallbackTemplateKey = "callback"
 }
 
 @UIApplicationMain
@@ -286,6 +288,16 @@ private extension AppDelegate
                 
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: AppDelegate.addSourceDeepLinkNotification, object: nil, userInfo: [AppDelegate.addSourceDeepLinkURLKey: sourceURL])
+                }
+                
+                return true
+            
+            case "certificate":
+                let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
+                guard let callbackTemplate = queryItems["callback"]?.removingPercentEncoding else { return false }
+                
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: AppDelegate.exportCertificateNotification, object: nil, userInfo: [AppDelegate.exportCertificateCallbackTemplateKey: callbackTemplate])
                 }
                 
                 return true

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -140,6 +140,14 @@ private extension SceneDelegate
                     NotificationCenter.default.post(name: AppDelegate.addSourceDeepLinkNotification, object: nil, userInfo: [AppDelegate.addSourceDeepLinkURLKey: sourceURL])
                 }
                 
+            case "certificate":
+                let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
+                guard let callbackTemplate = queryItems["callback_template"]?.removingPercentEncoding else { return }
+                
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: AppDelegate.exportCertificateNotification, object: nil, userInfo: [AppDelegate.exportCertificateCallbackTemplateKey: callbackTemplate])
+                }
+
             default: break
             }
         }

--- a/AltStore/TabBarController.swift
+++ b/AltStore/TabBarController.swift
@@ -36,6 +36,7 @@ final class TabBarController: UITabBarController
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.openPatreonSettings(_:)), name: AppDelegate.openPatreonSettingsDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.importApp(_:)), name: AppDelegate.importAppDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.presentSources(_:)), name: AppDelegate.addSourceDeepLinkNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportCertificate(_:)), name: AppDelegate.exportCertificateNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.openErrorLog(_:)), name: ToastView.openErrorLogNotification, object: nil)
     }
     
@@ -138,6 +139,11 @@ private extension TabBarController
     }
 
     @objc func openErrorLog(_ notification: Notification)
+    {
+        self.selectedIndex = Tab.settings.rawValue
+    }
+    
+    @objc func exportCertificate(_ notification: Notification)
     {
         self.selectedIndex = Tab.settings.rawValue
     }


### PR DESCRIPTION
### Changes

<!-- Fill this list with what your PR changes. Example: -->
- Add a URL Scheme so other apps (specifically LiveContainer) can get the certificate without injecting a certificate stealer

1. The app constructs a callback url like this: 
``` 
livecontainer://certificate?cert=$(BASE64_CERT)&password=$(PASSWORD)
```
Where `$(BASE64_CERT)` and `$(PASSWORD)` are placeholders SideStore will replace with base64 encoded certificate data and password.

Considering in most circumstances the password is actually empty for certificate stored in Keychain, only `$(BASE64_CERT)` is required

2. The app URL encode the link and send it to SideStore like this:
```
sidestore://certificate?callback_template=livecontainer%3A%2F%2Fcertificate%3Fcert%3D%24%28BASE64_CERT%29%26password%3D%24%28PASSWORD%29
```
3. SideStore parses the URL and decode the callback URL template 
4. SideStore opens a prompt asking user if the export is permitted
5. SideStore replaces the placeholders with actual URL encoded base64 encoded certificate data and password, and open it 