### PR TITLE
Feat: Add Pairing File Export URL callback and replace Wireguard with StosVPN

### DIFF
--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -242,7 +242,7 @@ private extension AppDelegate
             guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return false }
             guard let host = components.host?.lowercased() else { return false }
             
-            print(url.absoluteString)
+            Logger.main.info(url.absoluteString)
             
             switch host
             {
@@ -299,7 +299,10 @@ private extension AppDelegate
                 
             case "pairing":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
-                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return false }
+                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else {
+                    Logger.main.info("ohno")
+                    return false
+                }
                 
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -297,7 +297,7 @@ private extension AppDelegate
                 
             case "pairing":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
-                guard let callbackTemplate = queryItems["url"]?.removingPercentEncoding else { return false }
+                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return false }
                 
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -28,13 +28,10 @@ extension AppDelegate
     static let appBackupDidFinish = Notification.Name(Bundle.Info.appbundleIdentifier + ".AppBackupDidFinish")
     static let exportCertificateNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".ExportCertificateNotification")
     
-    static let exportPairingFileNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".ExportPairingFileNotification")
-    
     static let importAppDeepLinkURLKey = "fileURL"
     static let appBackupResultKey = "result"
     static let addSourceDeepLinkURLKey = "sourceURL"
     static let exportCertificateCallbackTemplateKey = "callback"
-    static let exportPairingCallbackTemplateKey = "pairing"
 }
 
 @UIApplicationMain
@@ -300,7 +297,7 @@ private extension AppDelegate
                 guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return false }
                 
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
+                    export(callbackTemplate)
                 }
                 
                 return true

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -242,7 +242,7 @@ private extension AppDelegate
             guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return false }
             guard let host = components.host?.lowercased() else { return false }
             
-            Logger.main.info(url.absoluteString)
+            Logger.main.info("\(url.absoluteString)")
             
             switch host
             {

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -28,13 +28,13 @@ extension AppDelegate
     static let appBackupDidFinish = Notification.Name(Bundle.Info.appbundleIdentifier + ".AppBackupDidFinish")
     static let exportCertificateNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".ExportCertificateNotification")
     
-    static let exportPairimgFileNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".ExportPairimgFileNotification")
+    static let exportPairingFileNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".ExportPairingFileNotification")
     
     static let importAppDeepLinkURLKey = "fileURL"
     static let appBackupResultKey = "result"
     static let addSourceDeepLinkURLKey = "sourceURL"
     static let exportCertificateCallbackTemplateKey = "callback"
-    static let exportPairingCallbackTemplateKey = "exampleApp"
+    static let exportPairingCallbackTemplateKey = "pairing"
 }
 
 @UIApplicationMain
@@ -300,7 +300,7 @@ private extension AppDelegate
                 guard let callbackTemplate = queryItems["url"]?.removingPercentEncoding else { return false }
                 
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: AppDelegate.exportPairimgFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
+                    NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
                 }
                 
                 return true

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -242,8 +242,6 @@ private extension AppDelegate
             guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return false }
             guard let host = components.host?.lowercased() else { return false }
             
-            Logger.main.info("\(url.absoluteString)")
-            
             switch host
             {
             case "patreon":
@@ -299,10 +297,7 @@ private extension AppDelegate
                 
             case "pairing":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
-                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else {
-                    Logger.main.info("ohno")
-                    return false
-                }
+                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return false }
                 
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -28,10 +28,13 @@ extension AppDelegate
     static let appBackupDidFinish = Notification.Name(Bundle.Info.appbundleIdentifier + ".AppBackupDidFinish")
     static let exportCertificateNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".ExportCertificateNotification")
     
+    static let exportPairimgFileNotification = Notification.Name(Bundle.Info.appbundleIdentifier + ".ExportPairimgFileNotification")
+    
     static let importAppDeepLinkURLKey = "fileURL"
     static let appBackupResultKey = "result"
     static let addSourceDeepLinkURLKey = "sourceURL"
     static let exportCertificateCallbackTemplateKey = "callback"
+    static let exportPairingCallbackTemplateKey = "exampleApp"
 }
 
 @UIApplicationMain
@@ -288,6 +291,16 @@ private extension AppDelegate
                 
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: AppDelegate.addSourceDeepLinkNotification, object: nil, userInfo: [AppDelegate.addSourceDeepLinkURLKey: sourceURL])
+                }
+                
+                return true
+                
+            case "pairing":
+                let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
+                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return false }
+                
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: AppDelegate.exportPairimgFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
                 }
                 
                 return true

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -297,7 +297,7 @@ private extension AppDelegate
                 guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return false }
                 
                 DispatchQueue.main.async {
-                    export(callbackTemplate)
+                    exportPairingFile(callbackTemplate)
                 }
                 
                 return true

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -242,6 +242,8 @@ private extension AppDelegate
             guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return false }
             guard let host = components.host?.lowercased() else { return false }
             
+            print(url.absoluteString)
+            
             switch host
             {
             case "patreon":
@@ -307,7 +309,7 @@ private extension AppDelegate
             
             case "certificate":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
-                guard let callbackTemplate = queryItems["callback"]?.removingPercentEncoding else { return false }
+                guard let callbackTemplate = queryItems["callback_template"]?.removingPercentEncoding else { return false }
                 
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: AppDelegate.exportCertificateNotification, object: nil, userInfo: [AppDelegate.exportCertificateCallbackTemplateKey: callbackTemplate])

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -297,7 +297,7 @@ private extension AppDelegate
                 
             case "pairing":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
-                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return false }
+                guard let callbackTemplate = queryItems["url"]?.removingPercentEncoding else { return false }
                 
                 DispatchQueue.main.async {
                     NotificationCenter.default.post(name: AppDelegate.exportPairimgFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])

--- a/AltStore/Authentication/Authentication.storyboard
+++ b/AltStore/Authentication/Authentication.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,7 +14,7 @@
             <objects>
                 <navigationController storyboardIdentifier="navigationController" id="ZTo-53-dSL" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" barStyle="black" largeTitles="YES" id="Aej-RF-PfV" customClass="NavigationBar" customModule="SideStore" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="96"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="barTintColor" name="SettingsBackground"/>
@@ -42,13 +42,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oyW-Fd-ojD" userLabel="Sizing View">
-                                <rect key="frame" x="0.0" y="44" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                             </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alwaysBounceVertical="YES" indicatorStyle="white" keyboardDismissMode="onDrag" translatesAutoresizingMaskIntoConstraints="NO" id="WXx-hX-AXv">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2wp-qG-f0Z">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="YmX-7v-pxh">
                                                 <rect key="frame" x="16" y="6" width="343" height="359.5"/>
@@ -57,13 +57,13 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="67.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to SideStore." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="EI2-V3-zQZ">
-                                                                <rect key="frame" x="0.0" y="0.0" width="333.5" height="41"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="41"/>
                                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="34"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign in with your Apple ID to get started." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="SNU-tv-8Au">
-                                                                <rect key="frame" x="0.0" y="47" width="308.5" height="20.5"/>
+                                                                <rect key="frame" x="0.0" y="47" width="306.5" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
@@ -160,7 +160,7 @@
                                                                     </stackView>
                                                                 </subviews>
                                                             </stackView>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2N5-zd-fUj">
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2N5-zd-fUj">
                                                                 <rect key="frame" x="0.0" y="191" width="343" height="51"/>
                                                                 <color key="backgroundColor" name="SettingsHighlighted"/>
                                                                 <constraints>
@@ -179,7 +179,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="DBk-rT-ZE8">
-                                                <rect key="frame" x="16" y="518.5" width="343" height="96.5"/>
+                                                <rect key="frame" x="16" y="498.5" width="343" height="96.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Why do we need this?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p9U-0q-Kn8">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
@@ -198,6 +198,10 @@
                                             </stackView>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="DBk-rT-ZE8" firstAttribute="leading" secondItem="2wp-qG-f0Z" secondAttribute="leadingMargin" id="5AT-nV-ZP9"/>
+                                            <constraint firstAttribute="bottomMargin" secondItem="DBk-rT-ZE8" secondAttribute="bottom" id="HgY-oY-8KM"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="DBk-rT-ZE8" secondAttribute="trailing" id="VCf-bW-2K4"/>
+                                            <constraint firstItem="YmX-7v-pxh" firstAttribute="top" secondItem="2wp-qG-f0Z" secondAttribute="top" constant="6" id="iUr-Nd-tkt"/>
                                             <constraint firstItem="DBk-rT-ZE8" firstAttribute="top" relation="greaterThanOrEqual" secondItem="YmX-7v-pxh" secondAttribute="bottom" constant="8" symbolic="YES" id="zTU-eY-DWd"/>
                                         </constraints>
                                     </view>
@@ -215,19 +219,15 @@
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="WXx-hX-AXv" secondAttribute="bottom" id="0jL-Ky-ju6"/>
                             <constraint firstAttribute="leadingMargin" secondItem="YmX-7v-pxh" secondAttribute="leading" id="2PO-lG-dmB"/>
-                            <constraint firstItem="DBk-rT-ZE8" firstAttribute="leading" secondItem="2wp-qG-f0Z" secondAttribute="leadingMargin" id="5AT-nV-ZP9"/>
                             <constraint firstItem="oyW-Fd-ojD" firstAttribute="top" secondItem="zMn-DV-fpy" secondAttribute="top" id="730-db-ukB"/>
-                            <constraint firstItem="2wp-qG-f0Z" firstAttribute="bottomMargin" secondItem="DBk-rT-ZE8" secondAttribute="bottom" id="HgY-oY-8KM"/>
                             <constraint firstItem="zMn-DV-fpy" firstAttribute="trailing" secondItem="oyW-Fd-ojD" secondAttribute="trailing" id="KGE-CN-SWf"/>
                             <constraint firstItem="WXx-hX-AXv" firstAttribute="top" secondItem="mjy-4S-hyH" secondAttribute="top" id="LPQ-bF-ic0"/>
                             <constraint firstItem="zMn-DV-fpy" firstAttribute="trailing" secondItem="WXx-hX-AXv" secondAttribute="trailing" id="MG7-A6-pKp"/>
                             <constraint firstAttribute="trailingMargin" secondItem="YmX-7v-pxh" secondAttribute="trailing" id="O4T-nu-o3e"/>
                             <constraint firstItem="zMn-DV-fpy" firstAttribute="bottom" secondItem="oyW-Fd-ojD" secondAttribute="bottom" id="PuX-ab-cEq"/>
                             <constraint firstItem="oyW-Fd-ojD" firstAttribute="leading" secondItem="zMn-DV-fpy" secondAttribute="leading" id="SzC-gC-Nvi"/>
-                            <constraint firstItem="2wp-qG-f0Z" firstAttribute="trailingMargin" secondItem="DBk-rT-ZE8" secondAttribute="trailing" id="VCf-bW-2K4"/>
                             <constraint firstItem="WXx-hX-AXv" firstAttribute="leading" secondItem="zMn-DV-fpy" secondAttribute="leading" id="d08-zF-5X6"/>
                             <constraint firstItem="2wp-qG-f0Z" firstAttribute="height" secondItem="oyW-Fd-ojD" secondAttribute="height" id="dFN-pw-TWt"/>
-                            <constraint firstItem="YmX-7v-pxh" firstAttribute="top" secondItem="2wp-qG-f0Z" secondAttribute="top" constant="6" id="iUr-Nd-tkt"/>
                             <constraint firstItem="2wp-qG-f0Z" firstAttribute="width" secondItem="oyW-Fd-ojD" secondAttribute="width" id="rYO-GN-0Lk"/>
                         </constraints>
                     </view>
@@ -264,7 +264,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="bp6-55-IG2">
-                                <rect key="frame" x="0.0" y="44" width="375" height="564"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="544"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="FjP-tm-w7K">
                                         <rect key="frame" x="16" y="35" width="343" height="95.5"/>
@@ -298,7 +298,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="LpI-Jt-SzX">
-                                        <rect key="frame" x="16" y="168" width="343" height="95.5"/>
+                                        <rect key="frame" x="16" y="161" width="343" height="95.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0LW-eE-qHa">
                                                 <rect key="frame" x="0.0" y="0.0" width="59" height="95.5"/>
@@ -310,7 +310,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="dMu-eg-gIO">
-                                                <rect key="frame" x="79" y="15.5" width="264" height="64"/>
+                                                <rect key="frame" x="79" y="16" width="264" height="64"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connect to Wi-Fi and VPN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="esj-pD-D4A">
                                                         <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
@@ -318,7 +318,7 @@
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable SideStore VPN in Wireguard and be able to use Sidestore on the go." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="4rk-ge-FSj">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable StosVPN and be able to use Sidestore on the go." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="4rk-ge-FSj">
                                                         <rect key="frame" x="0.0" y="25.5" width="264" height="38.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                         <color key="textColor" white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -329,7 +329,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="tfb-ja-9UC">
-                                        <rect key="frame" x="16" y="300.5" width="343" height="95.5"/>
+                                        <rect key="frame" x="16" y="287.5" width="343" height="95.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nVr-El-Csi">
                                                 <rect key="frame" x="0.0" y="0.0" width="59" height="95.5"/>
@@ -341,7 +341,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="z6Y-zi-teL">
-                                                <rect key="frame" x="79" y="16" width="264" height="64"/>
+                                                <rect key="frame" x="79" y="15.5" width="264" height="64"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Download Apps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="JeJ-bk-UCA">
                                                         <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
@@ -360,7 +360,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="X3r-G1-vf2">
-                                        <rect key="frame" x="16" y="433.5" width="343" height="95.5"/>
+                                        <rect key="frame" x="16" y="413.5" width="343" height="95.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i2U-NL-plG">
                                                 <rect key="frame" x="0.0" y="0.0" width="59" height="95.5"/>
@@ -372,7 +372,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Xs6-pJ-PUz">
-                                                <rect key="frame" x="79" y="16" width="264" height="64"/>
+                                                <rect key="frame" x="79" y="17" width="264" height="62"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Apps Refresh Automatically" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="nvb-Aq-sYa">
                                                         <rect key="frame" x="0.0" y="0.0" width="264" height="20.5"/>
@@ -381,7 +381,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Apps are refreshed in the background while you are on SideStore VPN!" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="HU5-Hv-E3d">
-                                                        <rect key="frame" x="0.0" y="25.5" width="264" height="38.5"/>
+                                                        <rect key="frame" x="0.0" y="25.5" width="264" height="36.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                         <color key="textColor" white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>

--- a/AltStore/Operations/Errors/OperationError.swift
+++ b/AltStore/Operations/Errors/OperationError.swift
@@ -220,7 +220,7 @@ struct OperationError: ALTLocalizedError {
         case .openAppFailed:
             let appName = self.appName ?? NSLocalizedString("The app", comment: "")
             return String(format: NSLocalizedString("SideStore was denied permission to launch %@.", comment: ""), appName)
-        case .noWiFi: return NSLocalizedString("You do not appear to be connected to WiFi and/or the WireGuard VPN!\nSideStore will never be able to install or refresh applications without WiFi and the WireGuard VPN.", comment: "")
+        case .noWiFi: return NSLocalizedString("You do not appear to be connected to WiFi and/or StosVPN!\nSideStore will never be able to install or refresh applications without WiFi and the StosVPN.", comment: "")
         case .tooNewError: return NSLocalizedString("iOS 17 has changed how JIT is enabled therefore SideStore cannot enable it without SideJITServer at this time, sorry for any inconvenience.\nWe will let everyone know once we have a solution!", comment: "")
         case .unableToConnectSideJIT: return NSLocalizedString("Unable to connect to SideJITServer Please check that you are on the Same Wi-Fi and your Firewall has been set correctly", comment: "")
         case .unableToRespondSideJITDevice: return NSLocalizedString("SideJITServer is unable to connect to your iDevice Please make sure you have paired your Device by doing 'SideJITServer -y' or try Refreshing SideJITServer from Settings", comment: "")
@@ -308,7 +308,7 @@ extension MinimuxerError: LocalizedError {
         case .NoDevice:
             return NSLocalizedString("Cannot fetch the device from the muxer", comment: "")
         case .NoConnection:
-            return NSLocalizedString("Unable to connect to the device, make sure Wireguard is enabled and you're connected to WiFi. This could mean an invalid pairing.", comment: "")
+            return NSLocalizedString("Unable to connect to the device, make sure StosVPN is enabled and you're connected to WiFi. This could mean an invalid pairing.", comment: "")
         case .PairingFile:
             return NSLocalizedString("Invalid pairing file. Your pairing file either didn't have a UDID, or it wasn't a valid plist. Please use jitterbugpair to generate it", comment: "")
             

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -93,6 +93,8 @@ private extension SceneDelegate
             guard let components = URLComponents(url: context.url, resolvingAgainstBaseURL: false) else { return }
             guard let host = components.host?.lowercased() else { return }
             
+            print(context.url.absoluteString)
+            
             switch host
             {
             case "patreon":

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -23,7 +23,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate
         
         if let context = connectionOptions.urlContexts.first
         {
-            // self.open(context)
+            self.open(context)
         }
     }
 
@@ -71,14 +71,14 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
     {
-        // guard let context = URLContexts.first else { return }
-        // self.open(context)
+        guard let context = URLContexts.first else { return }
+        self.open(context)
     }
 }
 
 private extension SceneDelegate
 {
-    func open1(_ context: UIOpenURLContext)
+    func open(_ context: UIOpenURLContext)
     {
         if context.url.isFileURL
         {

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -23,7 +23,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate
         
         if let context = connectionOptions.urlContexts.first
         {
-            self.open(context)
+            // self.open(context)
         }
     }
 
@@ -71,8 +71,8 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
     {
-        guard let context = URLContexts.first else { return }
-        self.open(context)
+        // guard let context = URLContexts.first else { return }
+        // self.open(context)
     }
 }
 

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -140,6 +140,14 @@ private extension SceneDelegate
                     NotificationCenter.default.post(name: AppDelegate.addSourceDeepLinkNotification, object: nil, userInfo: [AppDelegate.addSourceDeepLinkURLKey: sourceURL])
                 }
                 
+            case "pairing":
+                let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
+                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return }
+                
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(name: AppDelegate.exportPairimgFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
+                }
+                
             case "certificate":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
                 guard let callbackTemplate = queryItems["callback_template"]?.removingPercentEncoding else { return }

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -93,8 +93,6 @@ private extension SceneDelegate
             guard let components = URLComponents(url: context.url, resolvingAgainstBaseURL: false) else { return }
             guard let host = components.host?.lowercased() else { return }
             
-            Logger.main.info("\(components)")
-            
             switch host
             {
             case "patreon":
@@ -144,16 +142,16 @@ private extension SceneDelegate
                 
             case "pairing":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
+                Logger.main.info("queryItems \(queryItems)")
                 guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else {
                     Logger.main.info("ohno")
                     return
                 }
                 
                 DispatchQueue.main.async {
+                    openExportPairingFileConfirm(callbackTemplate)
                     NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
                 }
-                
-                openExportPairingFileConfirm(callbackTemplate)
                 
             case "certificate":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -171,7 +171,7 @@ private extension SceneDelegate
     func openExportPairingFileConfirm(_ template: String)
     {
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first, let viewcontroller = window.rootViewController? {
+           let window = windowScene.windows.first, let viewcontroller = window.rootViewController {
             func export()
             {
                 

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -146,7 +146,7 @@ private extension SceneDelegate
                 guard let callbackTemplate = queryItems["urlname"]?.removingPercentEncoding else { return }
                 
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
+                    export(callbackTemplate)
                 }
                 
             case "certificate":
@@ -160,5 +160,41 @@ private extension SceneDelegate
             default: break
             }
         }
+    }
+}
+
+
+func export(_ urlname: String) {
+    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+       let window = windowScene.windows.first, let viewcontroller = window.rootViewController {
+        let fm = FileManager.default
+        let documentsPath = fm.documentsDirectory.appendingPathComponent("ALTPairingFile.mobiledevicepairing")
+        
+        
+        guard let data = try? Data(contentsOf: documentsPath) else {
+            let toastView = ToastView(text: NSLocalizedString("Failed to find Pairing File!", comment: ""), detailText: nil)
+            toastView.show(in: viewcontroller)
+            return
+        }
+        
+        let base64encodedCert = data.base64EncodedString()
+        var allowedQueryParamAndKey = NSCharacterSet.urlQueryAllowed
+        allowedQueryParamAndKey.remove(charactersIn: ";/?:@&=+$, ")
+        guard let encodedCert = base64encodedCert.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey) else {
+            let toastView = ToastView(text: NSLocalizedString("Failed to encode pairingFile!", comment: ""), detailText: nil)
+            toastView.show(in: viewcontroller)
+            return
+        }
+        
+        var urlStr = "\(urlname)://pairingFile?data=$(BASE64_PAIRING)"
+        let finished = urlStr.replacingOccurrences(of: "$(BASE64_PAIRING)", with: encodedCert, options: .literal, range: nil)
+        
+        print(finished)
+        guard let callbackUrl = URL(string: finished) else {
+            let toastView = ToastView(text: NSLocalizedString("Failed to initialize callback URL!", comment: ""), detailText: nil)
+            toastView.show(in: viewcontroller)
+            return
+        }
+        UIApplication.shared.open(callbackUrl)
     }
 }

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -78,7 +78,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate
 
 private extension SceneDelegate
 {
-    func open(_ context: UIOpenURLContext)
+    func open1(_ context: UIOpenURLContext)
     {
         if context.url.isFileURL
         {

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -149,7 +149,7 @@ private extension SceneDelegate
                 }
                 
                 DispatchQueue.main.async {
-                    openExportPairingFileConfirm(callbackTemplate)
+                    self.openExportPairingFileConfirm(callbackTemplate)
                     NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
                 }
                 

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -146,7 +146,7 @@ private extension SceneDelegate
                 guard let callbackTemplate = queryItems["urlname"]?.removingPercentEncoding else { return }
                 
                 DispatchQueue.main.async {
-                    export(callbackTemplate)
+                    exportPairingFile(callbackTemplate)
                 }
                 
             case "certificate":
@@ -164,7 +164,7 @@ private extension SceneDelegate
 }
 
 
-func export(_ urlname: String) {
+func exportPairingFile(_ urlname: String) {
     if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
        let window = windowScene.windows.first, let viewcontroller = window.rootViewController {
         let fm = FileManager.default

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -93,7 +93,7 @@ private extension SceneDelegate
             guard let components = URLComponents(url: context.url, resolvingAgainstBaseURL: false) else { return }
             guard let host = components.host?.lowercased() else { return }
             
-            Logger.main.info("\(context.url.absoluteString)")
+            Logger.main.info("\(components)")
             
             switch host
             {

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -142,10 +142,13 @@ private extension SceneDelegate
                 
             case "pairing":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
-                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else { return }
+                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else {
+                    print("ohno")
+                    return
+                }
                 
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: AppDelegate.exportPairimgFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
+                    NotificationCenter.default.post(name: AppDelegate.exportPairingFileNotification, object: nil, userInfo: [AppDelegate.exportPairingCallbackTemplateKey: callbackTemplate])
                 }
                 
             case "certificate":

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -93,7 +93,7 @@ private extension SceneDelegate
             guard let components = URLComponents(url: context.url, resolvingAgainstBaseURL: false) else { return }
             guard let host = components.host?.lowercased() else { return }
             
-            Logger.main.info(context.url.absoluteString)
+            Logger.main.info("\(context.url.absoluteString)")
             
             switch host
             {
@@ -171,7 +171,7 @@ private extension SceneDelegate
     func openExportPairingFileConfirm(_ template: String)
     {
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first {
+           let window = windowScene.windows.first, let viewcontroller = window.rootViewController? {
             func export()
             {
                 
@@ -181,7 +181,7 @@ private extension SceneDelegate
                 
                 guard let data = try? Data(contentsOf: documentsPath) else {
                     let toastView = ToastView(text: NSLocalizedString("Failed to find Pairing File!", comment: ""), detailText: nil)
-                    toastView.show(in: self)
+                    toastView.show(in: viewcontroller)
                     return
                 }
                 
@@ -190,7 +190,7 @@ private extension SceneDelegate
                 allowedQueryParamAndKey.remove(charactersIn: ";/?:@&=+$, ")
                 guard let encodedCert = base64encodedCert.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey) else {
                     let toastView = ToastView(text: NSLocalizedString("Failed to encode pairingFile!", comment: ""), detailText: nil)
-                    toastView.show(in: self)
+                    toastView.show(in: viewcontroller)
                     return
                 }
                 
@@ -200,7 +200,7 @@ private extension SceneDelegate
                 print(finished)
                 guard let callbackUrl = URL(string: finished) else {
                     let toastView = ToastView(text: NSLocalizedString("Failed to initialize callback URL!", comment: ""), detailText: nil)
-                    toastView.show(in: self)
+                    toastView.show(in: viewcontroller)
                     return
                 }
                 UIApplication.shared.open(callbackUrl)
@@ -209,7 +209,7 @@ private extension SceneDelegate
             let alertController = UIAlertController(title: NSLocalizedString("Export Pairing File?", comment: ""), message: NSLocalizedString("Do you want to export your pairing file to an external app? That app will be able to access your device with StosVPN (open apps, sideload, enable JIT, etc).", comment: ""), preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: NSLocalizedString("Export", comment: ""), style: .default) { _ in export() })
             alertController.addAction(.cancel)
-            window.rootViewController?.present(alertController, animated: true, completion: nil)
+            viewcontroller.present(alertController, animated: true, completion: nil)
         }
     }
 }

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -143,7 +143,7 @@ private extension SceneDelegate
             case "pairing":
                 let queryItems = components.queryItems?.reduce(into: [String: String]()) { $0[$1.name.lowercased()] = $1.value } ?? [:]
                 Logger.main.info("queryItems \(queryItems)")
-                guard let callbackTemplate = queryItems["urlName"]?.removingPercentEncoding else {
+                guard let callbackTemplate = queryItems["urlname"]?.removingPercentEncoding else {
                     Logger.main.info("ohno")
                     return
                 }

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -814,6 +814,7 @@ private extension SettingsViewController
                 toastView.show(in: self)
                 return
             }
+
             let fm = FileManager.default
             let documentsPath = fm.documentsDirectory.appendingPathComponent("ALTPairingFile.mobiledevicepairing")
             

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -144,7 +144,6 @@ final class SettingsViewController: UITableViewController
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openPatreonSettings(_:)), name: AppDelegate.openPatreonSettingsDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openErrorLog(_:)), name: ToastView.openErrorLogNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openExportCertificateConfirm(_:)), name: AppDelegate.exportCertificateNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openExportPairingFileConfirm(_:)), name: AppDelegate.exportPairingFileNotification, object: nil)
     }
     
     

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -818,7 +818,7 @@ private extension SettingsViewController
             let documentsPath = fm.documentsDirectory.appendingPathComponent("ALTPairingFile.mobiledevicepairing")
             
             
-            guard let data = Data(contentsOf: documentsPath) else {
+            guard let data = try? Data(contentsOf: documentsPath) else {
                 let toastView = ToastView(text: NSLocalizedString("Failed to find Pairing File!", comment: ""), detailText: nil)
                 toastView.show(in: self)
                 return

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -144,7 +144,6 @@ final class SettingsViewController: UITableViewController
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openPatreonSettings(_:)), name: AppDelegate.openPatreonSettingsDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openErrorLog(_:)), name: ToastView.openErrorLogNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openExportCertificateConfirm(_:)), name: AppDelegate.exportCertificateNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openExportPairingFileConfirm(_:)), name: AppDelegate.exportPairingFileNotification, object: nil)
     }
     
     
@@ -804,45 +803,6 @@ private extension SettingsViewController
         alertController.addAction(UIAlertAction(title: NSLocalizedString("Export", comment: ""), style: .default) { _ in export() })
         alertController.addAction(.cancel)
         self.present(alertController, animated: true, completion: nil)
-    }
-    
-    @objc func openExportPairingFileConfirm(_ notification: Notification)
-    {
-        guard let template = notification.userInfo?[AppDelegate.exportPairingCallbackTemplateKey] as? String else {
-            let toastView = ToastView(text: NSLocalizedString("No App found!", comment: ""), detailText: nil)
-            toastView.show(in: self)
-            return
-        }
-
-        let fm = FileManager.default
-        let documentsPath = fm.documentsDirectory.appendingPathComponent("ALTPairingFile.mobiledevicepairing")
-        
-        
-        guard let data = try? Data(contentsOf: documentsPath) else {
-            let toastView = ToastView(text: NSLocalizedString("Failed to find Pairing File!", comment: ""), detailText: nil)
-            toastView.show(in: self)
-            return
-        }
-        
-        let base64encodedCert = data.base64EncodedString()
-        var allowedQueryParamAndKey = NSCharacterSet.urlQueryAllowed
-        allowedQueryParamAndKey.remove(charactersIn: ";/?:@&=+$, ")
-        guard let encodedCert = base64encodedCert.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey) else {
-            let toastView = ToastView(text: NSLocalizedString("Failed to encode pairingFile!", comment: ""), detailText: nil)
-            toastView.show(in: self)
-            return
-        }
-        
-        var urlStr = "\(template)://pairingFile?data=$(BASE64_PAIRING)"
-        let finished = urlStr.replacingOccurrences(of: "$(BASE64_PAIRING)", with: encodedCert, options: .literal, range: nil)
-        
-        print(finished)
-        guard let callbackUrl = URL(string: finished) else {
-            let toastView = ToastView(text: NSLocalizedString("Failed to initialize callback URL!", comment: ""), detailText: nil)
-            toastView.show(in: self)
-            return
-        }
-        UIApplication.shared.open(callbackUrl)
     }
 }
 

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -808,49 +808,41 @@ private extension SettingsViewController
     
     @objc func openExportPairingFileConfirm(_ notification: Notification)
     {
-        func export()
-        {
-            guard let template = notification.userInfo?[AppDelegate.exportPairingCallbackTemplateKey] as? String else {
-                let toastView = ToastView(text: NSLocalizedString("No App found!", comment: ""), detailText: nil)
-                toastView.show(in: self)
-                return
-            }
+        guard let template = notification.userInfo?[AppDelegate.exportPairingCallbackTemplateKey] as? String else {
+            let toastView = ToastView(text: NSLocalizedString("No App found!", comment: ""), detailText: nil)
+            toastView.show(in: self)
+            return
+        }
 
-            let fm = FileManager.default
-            let documentsPath = fm.documentsDirectory.appendingPathComponent("ALTPairingFile.mobiledevicepairing")
-            
-            
-            guard let data = try? Data(contentsOf: documentsPath) else {
-                let toastView = ToastView(text: NSLocalizedString("Failed to find Pairing File!", comment: ""), detailText: nil)
-                toastView.show(in: self)
-                return
-            }
-            
-            let base64encodedCert = data.base64EncodedString()
-            var allowedQueryParamAndKey = NSCharacterSet.urlQueryAllowed
-            allowedQueryParamAndKey.remove(charactersIn: ";/?:@&=+$, ")
-            guard let encodedCert = base64encodedCert.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey) else {
-                let toastView = ToastView(text: NSLocalizedString("Failed to encode pairingFile!", comment: ""), detailText: nil)
-                toastView.show(in: self)
-                return
-            }
-            
-            var urlStr = "\(template)://pairingFile?data=$(BASE64_PAIRING)"
-            let finished = urlStr.replacingOccurrences(of: "$(BASE64_PAIRING)", with: encodedCert, options: .literal, range: nil)
-            
-            print(finished)
-            guard let callbackUrl = URL(string: finished) else {
-                let toastView = ToastView(text: NSLocalizedString("Failed to initialize callback URL!", comment: ""), detailText: nil)
-                toastView.show(in: self)
-                return
-            }
-            UIApplication.shared.open(callbackUrl)
+        let fm = FileManager.default
+        let documentsPath = fm.documentsDirectory.appendingPathComponent("ALTPairingFile.mobiledevicepairing")
+        
+        
+        guard let data = try? Data(contentsOf: documentsPath) else {
+            let toastView = ToastView(text: NSLocalizedString("Failed to find Pairing File!", comment: ""), detailText: nil)
+            toastView.show(in: self)
+            return
         }
         
-        let alertController = UIAlertController(title: NSLocalizedString("Export Pairing File?", comment: ""), message: NSLocalizedString("Do you want to export your pairing file to an external app? That app will be able to access your device with StosVPN (open apps, sideload, enable JIT, etc).", comment: ""), preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: NSLocalizedString("Export", comment: ""), style: .default) { _ in export() })
-        alertController.addAction(.cancel)
-        self.present(alertController, animated: true, completion: nil)
+        let base64encodedCert = data.base64EncodedString()
+        var allowedQueryParamAndKey = NSCharacterSet.urlQueryAllowed
+        allowedQueryParamAndKey.remove(charactersIn: ";/?:@&=+$, ")
+        guard let encodedCert = base64encodedCert.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey) else {
+            let toastView = ToastView(text: NSLocalizedString("Failed to encode pairingFile!", comment: ""), detailText: nil)
+            toastView.show(in: self)
+            return
+        }
+        
+        var urlStr = "\(template)://pairingFile?data=$(BASE64_PAIRING)"
+        let finished = urlStr.replacingOccurrences(of: "$(BASE64_PAIRING)", with: encodedCert, options: .literal, range: nil)
+        
+        print(finished)
+        guard let callbackUrl = URL(string: finished) else {
+            let toastView = ToastView(text: NSLocalizedString("Failed to initialize callback URL!", comment: ""), detailText: nil)
+            toastView.show(in: self)
+            return
+        }
+        UIApplication.shared.open(callbackUrl)
     }
 }
 

--- a/AltStore/Settings/SettingsViewController.swift
+++ b/AltStore/Settings/SettingsViewController.swift
@@ -144,6 +144,7 @@ final class SettingsViewController: UITableViewController
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openPatreonSettings(_:)), name: AppDelegate.openPatreonSettingsDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openErrorLog(_:)), name: ToastView.openErrorLogNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openExportCertificateConfirm(_:)), name: AppDelegate.exportCertificateNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(SettingsViewController.openExportPairingFileConfirm(_:)), name: AppDelegate.exportPairingFileNotification, object: nil)
     }
     
     

--- a/AltStore/TabBarController.swift
+++ b/AltStore/TabBarController.swift
@@ -36,7 +36,8 @@ final class TabBarController: UITabBarController
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.openPatreonSettings(_:)), name: AppDelegate.openPatreonSettingsDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.importApp(_:)), name: AppDelegate.importAppDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.presentSources(_:)), name: AppDelegate.addSourceDeepLinkNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportCertificate(_:)), name: AppDelegate.exportCertificateNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportFiles(_:)), name: AppDelegate.exportCertificateNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportFiles(_:)), name: AppDelegate.exportPairimgFileNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.openErrorLog(_:)), name: ToastView.openErrorLogNotification, object: nil)
     }
     
@@ -143,7 +144,7 @@ private extension TabBarController
         self.selectedIndex = Tab.settings.rawValue
     }
     
-    @objc func exportCertificate(_ notification: Notification)
+    @objc func exportFiles(_ notification: Notification)
     {
         self.selectedIndex = Tab.settings.rawValue
     }

--- a/AltStore/TabBarController.swift
+++ b/AltStore/TabBarController.swift
@@ -37,7 +37,7 @@ final class TabBarController: UITabBarController
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.importApp(_:)), name: AppDelegate.importAppDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.presentSources(_:)), name: AppDelegate.addSourceDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportFiles(_:)), name: AppDelegate.exportCertificateNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportFiles(_:)), name: AppDelegate.exportPairimgFileNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportFiles(_:)), name: AppDelegate.exportPairingFileNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.openErrorLog(_:)), name: ToastView.openErrorLogNotification, object: nil)
     }
     

--- a/AltStore/TabBarController.swift
+++ b/AltStore/TabBarController.swift
@@ -37,7 +37,6 @@ final class TabBarController: UITabBarController
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.importApp(_:)), name: AppDelegate.importAppDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.presentSources(_:)), name: AppDelegate.addSourceDeepLinkNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportFiles(_:)), name: AppDelegate.exportCertificateNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.exportFiles(_:)), name: AppDelegate.exportPairingFileNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(TabBarController.openErrorLog(_:)), name: ToastView.openErrorLogNotification, object: nil)
     }
     


### PR DESCRIPTION
### Changes

The app has a URL Scheme like this e.g:
`stosvpn://pairingFile?data=(pairing data)`

The App calls the SideStore URL Scheme like this:
`sidestore://pairing?urlName=stosvpn`

The app gets the urlName (which is the URL Scheme name) and then constructs a new url using the url name and makes it as the one above

