### PR TITLE
fix(#703): Allow `mobiledevicepair` extension for pairing

### DIFF
--- a/AltStore/Info.plist
+++ b/AltStore/Info.plist
@@ -242,6 +242,7 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>mobiledevicepairing</string>
+					<string>mobiledevicepair</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
### Changes

- (Attempt to) fix #703

### Todo before merge
- [ ] Test



*(remade #896 by @nythepegasus as there was a conflict and we thought it would be better to remake the PR)*