### PR TITLE
Add option for sharing sources

### DIFF
--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -405,6 +405,13 @@ extension AppManager
         
         NotificationCenter.default.post(name: AppManager.didRemoveSourceNotification, object: source)
     }
+
+    func share(_ source: Source, presentingViewController: UIViewController) -> Bool
+    {
+        let shareSheet = UIActivityViewController(activityItems: [source], applicationActivities: nil)
+        presentingViewController.present(shareSheet, animated:true)
+        return true
+    }
     
     @discardableResult
     func installAsync<T: AppProtocol>(@AsyncManaged _ app: T, presentingViewController: UIViewController?, context: AuthenticatedOperationContext = AuthenticatedOperationContext(),

--- a/AltStore/Sources/Components/SourceHeaderView.swift
+++ b/AltStore/Sources/Components/SourceHeaderView.swift
@@ -16,6 +16,7 @@ import Nuke
 class SourceHeaderView: RSTNibView
 {
     @IBOutlet private(set) var titleLabel: UILabel!
+    @IBOutlet private(set) var subtitleContainer: UIView!
     @IBOutlet private(set) var subtitleLabel: UILabel!
     @IBOutlet private(set) var iconImageView: UIImageView!
     @IBOutlet private(set) var websiteButton: UIButton!
@@ -25,7 +26,8 @@ class SourceHeaderView: RSTNibView
     @IBOutlet private var websiteImageView: UIImageView!
     
     @IBOutlet private var widthConstraint: NSLayoutConstraint!
-    
+
+    private(set) lazy var shareButton = UIButton(type: .system, primaryAction: nil)
     override init(frame: CGRect)
     {
         super.init(frame: frame)
@@ -60,6 +62,17 @@ class SourceHeaderView: RSTNibView
         
         self.websiteButtonContainerView.clipsToBounds = true
         self.websiteButtonContainerView.layer.cornerRadius = 14 // 22 - inset (8)
+
+        if let iconContainer = iconImageView.superview {
+            let image = UIImage(systemName: "square.and.arrow.up.fill", withConfiguration: UIImage.SymbolConfiguration(font: titleFont))
+            shareButton.setImage(image, for: .normal)
+            addSubview(shareButton)
+            shareButton.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                shareButton.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+                shareButton.trailingAnchor.constraint(equalTo: iconContainer.trailingAnchor),
+            ])
+        }
     }
     
     override func layoutSubviews()
@@ -83,7 +96,9 @@ extension SourceHeaderView
     {
         self.titleLabel.text = source.name
         self.subtitleLabel.text = source.subtitle
-        
+        // hide subtitle for better alignment when subtitle is missing or empty
+        self.subtitleContainer.isHidden = self.subtitleLabel.text?.isEmpty != true
+
         self.websiteImageView.tintColor = source.effectiveTintColor
         
         if let websiteURL = source.websiteURL
@@ -102,5 +117,8 @@ extension SourceHeaderView
         }
         
         Nuke.loadImage(with: source.effectiveIconURL, into: self.iconImageView)
+
+        shareButton.isHidden = !source.isShareable
+        shareButton.tintColor = titleLabel.textColor
     }
 }

--- a/AltStore/Sources/Components/SourceHeaderView.swift
+++ b/AltStore/Sources/Components/SourceHeaderView.swift
@@ -15,6 +15,8 @@ import Nuke
 
 class SourceHeaderView: RSTNibView
 {
+    @IBOutlet private(set) var infoContainer: UIView!
+
     @IBOutlet private(set) var titleLabel: UILabel!
     @IBOutlet private(set) var subtitleContainer: UIView!
     @IBOutlet private(set) var subtitleLabel: UILabel!
@@ -63,16 +65,14 @@ class SourceHeaderView: RSTNibView
         self.websiteButtonContainerView.clipsToBounds = true
         self.websiteButtonContainerView.layer.cornerRadius = 14 // 22 - inset (8)
 
-        if let iconContainer = iconImageView.superview {
-            let image = UIImage(systemName: "square.and.arrow.up.fill", withConfiguration: UIImage.SymbolConfiguration(font: titleFont))
-            shareButton.setImage(image, for: .normal)
-            addSubview(shareButton)
-            shareButton.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                shareButton.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
-                shareButton.trailingAnchor.constraint(equalTo: iconContainer.trailingAnchor),
-            ])
-        }
+        let image = UIImage(systemName: "square.and.arrow.up.fill", withConfiguration: UIImage.SymbolConfiguration(font: titleFont))
+        shareButton.setImage(image, for: .normal)
+        addSubview(shareButton)
+        shareButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            shareButton.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+            shareButton.trailingAnchor.constraint(equalTo: infoContainer.trailingAnchor),
+        ])
     }
     
     override func layoutSubviews()

--- a/AltStore/Sources/Components/SourceHeaderView.xib
+++ b/AltStore/Sources/Components/SourceHeaderView.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SourceHeaderView" customModule="AltStore" customModuleProvider="target">
             <connections>
                 <outlet property="iconImageView" destination="rfC-wI-8JY" id="1FW-GN-WDa"/>
+                <outlet property="infoContainer" destination="hfp-yJ-gcH" id="hUa-dC-yco"/>
                 <outlet property="subtitleContainer" destination="7WA-03-aKF" id="5Zr-M3-Df1"/>
                 <outlet property="subtitleLabel" destination="IUL-qI-QAg" id="RyD-ax-OtJ"/>
                 <outlet property="titleLabel" destination="FsG-Wm-6xP" id="huW-re-9G0"/>

--- a/AltStore/Sources/Components/SourceHeaderView.xib
+++ b/AltStore/Sources/Components/SourceHeaderView.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SourceHeaderView" customModule="AltStore" customModuleProvider="target">
             <connections>
                 <outlet property="iconImageView" destination="rfC-wI-8JY" id="1FW-GN-WDa"/>
+                <outlet property="subtitleContainer" destination="7WA-03-aKF" id="5Zr-M3-Df1"/>
                 <outlet property="subtitleLabel" destination="IUL-qI-QAg" id="RyD-ax-OtJ"/>
                 <outlet property="titleLabel" destination="FsG-Wm-6xP" id="huW-re-9G0"/>
                 <outlet property="websiteButton" destination="cDF-t8-8Ri" id="6YC-OT-StI"/>

--- a/AltStore/Sources/SourceDetailViewController.swift
+++ b/AltStore/Sources/SourceDetailViewController.swift
@@ -158,6 +158,7 @@ class SourceDetailViewController: HeaderContentViewController<SourceHeaderView, 
         let sourceAboutView = SourceHeaderView(frame: CGRect(x: 0, y: 0, width: 375, height: 200))
         sourceAboutView.configure(for: self.source)
         sourceAboutView.websiteButton.addTarget(self, action: #selector(SourceDetailViewController.showWebsite), for: .primaryActionTriggered)
+        sourceAboutView.shareButton.addTarget(self, action: #selector(SourceDetailViewController.shareSource), for: .primaryActionTriggered)
         return sourceAboutView
     }
     
@@ -261,7 +262,12 @@ class SourceDetailViewController: HeaderContentViewController<SourceHeaderView, 
             self.viewModel.isAddingSource = false
         }
     }
-    
+
+    @objc private func shareSource()
+    {
+        _ = AppManager.shared.share(source, presentingViewController: self)
+    }
+
     @objc private func showWebsite()
     {
         guard let websiteURL = self.source.websiteURL else { return }

--- a/AltStore/Sources/SourcesViewController.swift
+++ b/AltStore/Sources/SourcesViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import CoreData
-
+import LinkPresentation
 import AltStoreCore
 import Roxas
 import Nuke
@@ -153,7 +153,17 @@ private extension SourcesViewController
                 
                 actions.append(removeAction)
             }
-            
+
+            if source.isShareable {
+                let shareAction = UIContextualAction(style: .normal,
+                                                      title: NSLocalizedString("Share", comment: "")) { _, _, completion in
+                    self.share(source, completionHandler: completion)
+                }
+                shareAction.image = UIImage(systemName: "square.and.arrow.up.fill")
+                shareAction.backgroundColor = source.effectiveTintColor
+                actions.append(shareAction)
+            }
+
             if let error = source.error
             {
                 let viewErrorAction = UIContextualAction(style: .normal,
@@ -399,7 +409,13 @@ private extension SourcesViewController
         alertController.addAction(.ok)
         self.present(alertController, animated: true, completion: nil)
     }
-    
+
+    func share(_ source: Source, completionHandler: ((Bool) -> Void)? = nil)
+    {
+        let result = AppManager.shared.share(source, presentingViewController: self)
+        completionHandler?(result)
+    }
+
     func remove(_ source: Source, completionHandler: ((Bool) -> Void)? = nil)
     {
         Task<Void, Never> {
@@ -554,4 +570,28 @@ extension SourcesViewController: NSFetchedResultsControllerDelegate
     }
     
     return sourcesViewController
+}
+
+extension Source: @retroactive UIActivityItemSource {
+    public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        sourceURL
+    }
+
+    public func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        sourceURL
+    }
+
+    public func activityViewControllerLinkMetadata(_: UIActivityViewController) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.originalURL = sourceURL
+        metadata.url = metadata.originalURL
+        metadata.title = name
+        if let effectiveIconURL, let image = ImageCache.shared[effectiveIconURL]?.image {
+            metadata.iconProvider = NSItemProvider(object: image)
+        }
+        if let effectiveHeaderImageURL, let image = ImageCache.shared[effectiveHeaderImageURL]?.image {
+            metadata.imageProvider = NSItemProvider(object: image)
+        }
+        return metadata
+    }
 }

--- a/AltStore/Sources/SourcesViewController.swift
+++ b/AltStore/Sources/SourcesViewController.swift
@@ -573,17 +573,29 @@ extension SourcesViewController: NSFetchedResultsControllerDelegate
 }
 
 extension Source: @retroactive UIActivityItemSource {
+    var deepLinkSourceURL: URL? {
+        var components = URLComponents(string: "sidestore://source")
+        components?.queryItems = [
+            URLQueryItem(name: "url", value: sourceURL.absoluteString)
+        ]
+        return components?.url
+    }
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         sourceURL
     }
 
     public func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
-        sourceURL
+        if [.copyToPasteboard].contains(activityType) {
+            return sourceURL
+        } else {
+            // Share deep link when sending to somewhere else, like AirDrop
+            return deepLinkSourceURL
+        }
     }
 
     public func activityViewControllerLinkMetadata(_: UIActivityViewController) -> LPLinkMetadata? {
         let metadata = LPLinkMetadata()
-        metadata.originalURL = sourceURL
+        metadata.originalURL = deepLinkSourceURL
         metadata.url = metadata.originalURL
         metadata.title = name
         if let effectiveIconURL, let image = ImageCache.shared[effectiveIconURL]?.image {

--- a/AltStoreCore/Model/Source.swift
+++ b/AltStoreCore/Model/Source.swift
@@ -203,6 +203,10 @@ public extension Source
      var effectiveFeaturedApps: [StoreApp] {
          return self.featuredApps ?? self.apps
      }
+
+     var isShareable: Bool {
+         identifier != Source.altStoreIdentifier
+     }
  }
 
 @objc(Source)


### PR DESCRIPTION
Today I was migrating my SideStore to another device, but I didn't find a way to easily migrate my existing sources, so I am thinking of adding a share option for sources without changing too much of the current UI architecture. 

### Changes

- Add an option for sharing shareable sources(any source that isn't the official one)
- Add a share contextual button in the sources tab
- Add an overlay share button in the source header view
- Hide the source subtitle when it’s missing or empty to align the title 'right' in the centre

## Preview
<img width="200" alt="image" src="https://github.com/user-attachments/assets/5695aca4-9ec4-4f16-a98e-af0a9068ff28" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/d721ca44-1fd0-49df-8cb9-b438d6202b4c" /> <img width="200" alt="image" src="https://github.com/user-attachments/assets/20c0a896-7534-4c7f-ae5f-fb009859e410" />

<img width="572" height="400" alt="View recent photos" src="https://github.com/user-attachments/assets/8c473a92-162c-442e-891c-49409a925fdb" />
