### PR TITLE
Fix crash when installing apps, fix useMainProfile not saved/ initialized

### DIFF
--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -93,7 +93,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         self.setTintColor()
-        self.setTintColor()
         self.prepareImageCache()
 
         // TODO: @mahee96: find if we need to start em_proxy as in altstore?

--- a/AltStore/Browse/FeaturedViewController.swift
+++ b/AltStore/Browse/FeaturedViewController.swift
@@ -368,7 +368,7 @@ private extension FeaturedViewController
             #keyPath(StoreApp._source._apps),
             #keyPath(StoreApp.bundleIdentifier),
             StoreApp.altstoreAppID,
-            #keyPath(StoreApp.installedApp),
+            #keyPath(StoreApp.installedApp)
         )
         
         let primaryFetchRequest = fetchRequest.copy() as! NSFetchRequest<StoreApp>

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -176,6 +176,13 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             
             var installing = true
             if installedApp.storeApp?.bundleIdentifier.range(of: Bundle.Info.appbundleIdentifier) != nil {
+                do {
+                    // we need to flush changes to the disk now in case the changes are lost when iOS kills current process
+                    try installedApp.managedObjectContext?.save()
+                } catch {
+                    print("Failed to flush installedApp to disk: \(error)")
+                }
+                
                 // Reinstalling ourself will hang until we leave the app, so we need to exit it without force closing
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                     if UIApplication.shared.applicationState != .active {

--- a/AltStoreCore/Model/DatabaseManager/DatabaseManager.swift
+++ b/AltStoreCore/Model/DatabaseManager/DatabaseManager.swift
@@ -399,6 +399,40 @@ private extension DatabaseManager
                 // For backwards compatibility reasons, we cannot use localApp's buildVersion as storeBuildVersion,
                 // or else the latest update will _always_ be considered new because we don't use buildVersions in our source (yet).
                 installedApp = InstalledApp(resignedApp: localApp, originalBundleIdentifier: StoreApp.altstoreAppID, certificateSerialNumber: serialNumber, storeBuildVersion: nil, context: context)
+                
+                // figure out if the current AltStoreApp is signed with "Use Main Profie" option
+                // by checking if the first extension's entitlement's application-identifier matches current one
+                repeat {
+                    guard let pluginURL = Bundle.main.builtInPlugInsURL else {
+                        installedApp.useMainProfile = true
+                        break
+                    }
+                    guard let pluginFolders = try? FileManager.default.contentsOfDirectory(at: pluginURL, includingPropertiesForKeys: nil) else {
+                        installedApp.useMainProfile = true
+                        break
+                    }
+                    
+                    guard let pluginFolder = pluginFolders.first, let altPluginApp = ALTApplication(fileURL: pluginFolder) else {
+                        installedApp.useMainProfile = true
+                        break
+                    }
+                    
+                    let entitlements = altPluginApp.entitlements
+                    guard let appId = entitlements[ALTEntitlement.applicationIdentifier] as? String else {
+                        installedApp.useMainProfile = false
+                        print("no ALTEntitlementApplicationIdentifier???")
+                        break
+                    }
+                    
+                    if appId.hasSuffix(Bundle.main.bundleIdentifier!) {
+                        installedApp.useMainProfile = true
+                    } else {
+                        installedApp.useMainProfile = false
+                    }
+                    
+                    
+                } while(false)
+                
                 installedApp.storeApp = storeApp
             }
             

--- a/SideStore/MinimuxerWrapper.swift
+++ b/SideStore/MinimuxerWrapper.swift
@@ -55,7 +55,8 @@ func yeetAppAFC(_ bundleId: String, _ rawBytes: Data) throws {
     #if targetEnvironment(simulator)
     print("yeetAppAFC(\(bundleId), \(rawBytes)) is no-op on simulator")
     #else
-    try minimuxer.yeet_app_afc(bundleId, rawBytes.toRustByteSlice().forRust())
+    let slice = rawBytes.toRustByteSlice()
+    try minimuxer.yeet_app_afc(bundleId, slice.forRust())
     #endif
 }
 


### PR DESCRIPTION
### Changes
Fix crash when installing apps after refactoring: break the 1 statement into 2 so the slice won't get deallocated

fix useMainProfile not saved because SideStore is killed by iOS before CoreData commits changes to db.

Detect if the app is installed with useMainProfile by checking if applicationIdentifier matches