### PR TITLE
Fix issues profile/afc and use main profile issue

### DIFF
--- a/AltStore.xcodeproj/project.pbxproj
+++ b/AltStore.xcodeproj/project.pbxproj
@@ -2413,6 +2413,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		177EF33D2F4D8B8E008CAAE1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"NSAttributedString+Markdown.m",
+			);
+			target = BFD247692284B9A500981D42 /* SideStore */;
+		};
 		A8A5AFBE2F4C33A300572B4A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -2670,7 +2677,7 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		A8A5AC9D2F4C338F00572B4A /* Roxas */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Roxas; sourceTree = "<group>"; };
-		A8A5ACE42F4C339400572B4A /* MarkdownAttributedString */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = MarkdownAttributedString; sourceTree = "<group>"; };
+		A8A5ACE42F4C339400572B4A /* MarkdownAttributedString */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (177EF33D2F4D8B8E008CAAE1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = MarkdownAttributedString; sourceTree = "<group>"; };
 		A8A5AE1B2F4C33A300572B4A /* libplist */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8A5AFC02F4C33A300572B4A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = libplist; sourceTree = "<group>"; };
 		A8A5AE662F4C33A300572B4A /* libimobiledevice-glue */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8A5AFBF2F4C33A300572B4A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "libimobiledevice-glue"; sourceTree = "<group>"; };
 		A8A5AF5E2F4C33A300572B4A /* libimobiledevice */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8A5AFBE2F4C33A300572B4A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = libimobiledevice; sourceTree = "<group>"; };

--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -93,7 +93,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         self.setTintColor()
-        self.setTintColor()
         self.prepareImageCache()
 
         // TODO: @mahee96: find if we need to start em_proxy as in altstore?

--- a/AltStore/Browse/FeaturedViewController.swift
+++ b/AltStore/Browse/FeaturedViewController.swift
@@ -368,7 +368,7 @@ private extension FeaturedViewController
             #keyPath(StoreApp._source._apps),
             #keyPath(StoreApp.bundleIdentifier),
             StoreApp.altstoreAppID,
-            #keyPath(StoreApp.installedApp),
+            #keyPath(StoreApp.installedApp)
         )
         
         let primaryFetchRequest = fetchRequest.copy() as! NSFetchRequest<StoreApp>

--- a/AltStore/Operations/InstallAppOperation.swift
+++ b/AltStore/Operations/InstallAppOperation.swift
@@ -176,6 +176,13 @@ final class InstallAppOperation: ResultOperation<InstalledApp>
             
             var installing = true
             if installedApp.storeApp?.bundleIdentifier.range(of: Bundle.Info.appbundleIdentifier) != nil {
+                do {
+                    // we need to flush changes to the disk now in case the changes are lost when iOS kills current process
+                    try installedApp.managedObjectContext?.save()
+                } catch {
+                    print("Failed to flush installedApp to disk: \(error)")
+                }
+                
                 // Reinstalling ourself will hang until we leave the app, so we need to exit it without force closing
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                     if UIApplication.shared.applicationState != .active {

--- a/AltStoreCore/Model/DatabaseManager/DatabaseManager.swift
+++ b/AltStoreCore/Model/DatabaseManager/DatabaseManager.swift
@@ -399,6 +399,40 @@ private extension DatabaseManager
                 // For backwards compatibility reasons, we cannot use localApp's buildVersion as storeBuildVersion,
                 // or else the latest update will _always_ be considered new because we don't use buildVersions in our source (yet).
                 installedApp = InstalledApp(resignedApp: localApp, originalBundleIdentifier: StoreApp.altstoreAppID, certificateSerialNumber: serialNumber, storeBuildVersion: nil, context: context)
+                
+                // figure out if the current AltStoreApp is signed with "Use Main Profie" option
+                // by checking if the first extension's entitlement's application-identifier matches current one
+                repeat {
+                    guard let pluginURL = Bundle.main.builtInPlugInsURL else {
+                        installedApp.useMainProfile = true
+                        break
+                    }
+                    guard let pluginFolders = try? FileManager.default.contentsOfDirectory(at: pluginURL, includingPropertiesForKeys: nil) else {
+                        installedApp.useMainProfile = true
+                        break
+                    }
+                    
+                    guard let pluginFolder = pluginFolders.first, let altPluginApp = ALTApplication(fileURL: pluginFolder) else {
+                        installedApp.useMainProfile = true
+                        break
+                    }
+                    
+                    let entitlements = altPluginApp.entitlements
+                    guard let appId = entitlements[ALTEntitlement.applicationIdentifier] as? String else {
+                        installedApp.useMainProfile = false
+                        print("no ALTEntitlementApplicationIdentifier???")
+                        break
+                    }
+                    
+                    if appId.hasSuffix(Bundle.main.bundleIdentifier!) {
+                        installedApp.useMainProfile = true
+                    } else {
+                        installedApp.useMainProfile = false
+                    }
+                    
+                    
+                } while(false)
+                
                 installedApp.storeApp = storeApp
             }
             

--- a/SideStore/MinimuxerWrapper.swift
+++ b/SideStore/MinimuxerWrapper.swift
@@ -55,7 +55,8 @@ func yeetAppAFC(_ bundleId: String, _ rawBytes: Data) throws {
     #if targetEnvironment(simulator)
     print("yeetAppAFC(\(bundleId), \(rawBytes)) is no-op on simulator")
     #else
-    try minimuxer.yeet_app_afc(bundleId, rawBytes.toRustByteSlice().forRust())
+    let slice = rawBytes.toRustByteSlice()
+    try minimuxer.yeet_app_afc(bundleId, slice.forRust())
     #endif
 }
 

--- a/SideStore/MinimuxerWrapper.swift
+++ b/SideStore/MinimuxerWrapper.swift
@@ -37,7 +37,8 @@ func installProvisioningProfiles(_ profileData: Data) throws {
     #if targetEnvironment(simulator)
     print("installProvisioningProfiles(\(profileData)) is no-op on simulator")
     #else
-    try minimuxer.install_provisioning_profile(profileData.toRustByteSlice().forRust())
+    let slice = profileData.toRustByteSlice()
+    try minimuxer.install_provisioning_profile(slice.forRust())
     #endif
 }
 


### PR DESCRIPTION
### Changes

Fix crash when sending app through afc / installing profiles after refactoring: break 1 statement into 2 so the slice won't get deallocated

Fix crash when viewing app ids caused by not NSAttributedString+Markdown.m being compiled

fix useMainProfile not saved because SideStore is killed by iOS before CoreData commits changes to db.

Detect if the app is installed with useMainProfile by checking if extension's applicationIdentifier matches SideStore's