### PR TITLE
feat: add Mona to Trusted Sources

### DIFF
--- a/trustedapps.json
+++ b/trustedapps.json
@@ -78,7 +78,7 @@
     },
     {
       "identifier": "com.deliacheminot.mona",
-      "sourceURL": "https://github.com/delia-cheminot/mona-hrt/blob/main/ios_source.json"
+      "sourceURL": "https://raw.githubusercontent.com/delia-cheminot/mona-hrt/refs/heads/main/ios_source.json"
     }
   ],
   "sources": [
@@ -155,7 +155,7 @@
     },
     {
       "identifier": "com.deliacheminot.mona",
-      "sourceURL": "https://github.com/delia-cheminot/mona-hrt/blob/main/ios_source.json"
+      "sourceURL": "https://raw.githubusercontent.com/delia-cheminot/mona-hrt/refs/heads/main/ios_source.json"
     }
   ]
 }

--- a/trustedapps.json
+++ b/trustedapps.json
@@ -75,6 +75,10 @@
     {
       "identifier": "thatstel.la.altsource",
       "sourceURL": "https://alt.thatstel.la/"
+    },
+    {
+      "identifier": "com.deliacheminot.mona",
+      "sourceURL": "https://github.com/delia-cheminot/mona-hrt/blob/main/ios_source.json"
     }
   ],
   "sources": [
@@ -148,6 +152,10 @@
     {
       "identifier": "thatstel.la.altsource",
       "sourceURL": "https://alt.thatstel.la/"
+    },
+    {
+      "identifier": "com.deliacheminot.mona",
+      "sourceURL": "https://github.com/delia-cheminot/mona-hrt/blob/main/ios_source.json"
     }
   ]
 }


### PR DESCRIPTION
### Changes
This PR adds [Mona](https://github.com/delia-cheminot/mona-hrt/tree/main) as a Trusted Source to SideStore.

Related: https://github.com/delia-cheminot/mona-hrt/pull/69. Should still work as-is.