### PR TITLE
Scale news images

### DIFF
--- a/AltStore/News/NewsCollectionViewCell.swift
+++ b/AltStore/News/NewsCollectionViewCell.swift
@@ -29,5 +29,6 @@ final class NewsCollectionViewCell: UICollectionViewCell
         
         self.imageView.layer.cornerRadius = 30
         self.imageView.clipsToBounds = true
+        self.imageView.contentMode = .scaleAspectFit
     }
 }


### PR DESCRIPTION
### Changes

| Before | After |
| --- | --- |
| <img width="568" height="1084" alt="Screenshot 2026-03-31 at 22 47 11" src="https://github.com/user-attachments/assets/7cdd1cd7-d833-44ca-a868-4400a70cd4e0" /> | <img width="568" height="1084" alt="Screenshot 2026-03-31 at 22 48 17" src="https://github.com/user-attachments/assets/35b344e8-42ed-4aab-9e8c-8634ea853f3f" /> |
