### PR TITLE
Replace “Log In” with “Sign In” for consistency

### DIFF
--- a/AltStore/Authentication/AuthenticationViewController.swift
+++ b/AltStore/Authentication/AuthenticationViewController.swift
@@ -122,7 +122,7 @@ private extension AuthenticationViewController
                 
             case .failure(let error as NSError):
                 DispatchQueue.main.async {
-                    let error = error.withLocalizedTitle(NSLocalizedString("Failed to Log In", comment: ""))
+                    let error = error.withLocalizedTitle(NSLocalizedString("Failed to Sign In", comment: ""))
                     let toastView = ToastView(error: error)
                     toastView.show(in: self)
                     toastView.backgroundColor = .white


### PR DESCRIPTION
This replaces "Log In" because "Sign In" is used [everywhere else](https://github.com/search?q=repo%3ASideStore%2FSideStore+%22sign+in%22&type=code).