### PR TITLE
fix: robust shared .ipa import (copy out of security scope + cold-launch defer)

### DIFF
--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -43,7 +43,11 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     private let viewAppIntentHandler = ViewAppIntentHandler()
     
     public let consoleLog = ConsoleLog()
-    
+
+    // Holds an imported .ipa URL when the app isn't active yet (cold launch),
+    // so the import notification can be posted once the app becomes active.
+    private var pendingImportIPAURL: URL?
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
     {
         // navigation bar buttons spacing is too much (so hack it to use minimal spacing)
@@ -146,7 +150,15 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
             startEMProxy(bind_addr: AppConstants.Proxy.serverURL)
         }
     }
-    
+
+    func applicationDidBecomeActive(_ application: UIApplication)
+    {
+        // Flush any .ipa import that arrived before the app was active (cold launch).
+        guard let url = self.pendingImportIPAURL else { return }
+        self.pendingImportIPAURL = nil
+        NotificationCenter.default.post(name: AppDelegate.importAppDeepLinkNotification, object: nil, userInfo: [AppDelegate.importAppDeepLinkURLKey: url])
+    }
+
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool
     {
         return self.open(url)
@@ -230,11 +242,38 @@ private extension AppDelegate
         if url.isFileURL
         {
             guard url.pathExtension.lowercased() == "ipa" else { return false }
-            
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: AppDelegate.importAppDeepLinkNotification, object: nil, userInfo: [AppDelegate.importAppDeepLinkURLKey: url])
+
+            // Copy the shared .ipa out of its security-scoped location into a
+            // temporary directory we own, so it stays readable while signing.
+            let didStartAccessing = url.startAccessingSecurityScopedResource()
+            defer {
+                if didStartAccessing { url.stopAccessingSecurityScopedResource() }
             }
-            
+
+            let temporaryDirectory = FileManager.default.uniqueTemporaryURL()
+            do {
+                try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                print("[ALTLog] Failed to create temp directory for imported IPA: \(error)")
+                return false
+            }
+
+            let ipaURL = temporaryDirectory.appendingPathComponent(url.lastPathComponent)
+
+            do {
+                try FileManager.default.copyItem(at: url, to: ipaURL)
+            } catch {
+                print("[ALTLog] Failed to copy imported IPA: \(error)")
+                return false
+            }
+
+            if UIApplication.shared.applicationState == .active {
+                NotificationCenter.default.post(name: AppDelegate.importAppDeepLinkNotification, object: nil, userInfo: [AppDelegate.importAppDeepLinkURLKey: ipaURL])
+            } else {
+                // Defer until the app is active (cold launch) — see applicationDidBecomeActive.
+                self.pendingImportIPAURL = ipaURL
+            }
+
             return true
         }
         else

--- a/AltStore/SceneDelegate.swift
+++ b/AltStore/SceneDelegate.swift
@@ -15,6 +15,10 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate
 {
     var window: UIWindow?
 
+    // Holds an imported .ipa URL when the scene isn't active yet (cold launch),
+    // so the import notification can be posted once the scene becomes active.
+    private var pendingImportIPAURL: URL?
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions)
     {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -43,6 +47,14 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate
         if UserDefaults.standard.enableEMPforWireguard {
             startEMProxy(bind_addr: AppConstants.Proxy.serverURL)
         }
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene)
+    {
+        // Flush any .ipa import that arrived before the scene was active (cold launch).
+        guard let url = self.pendingImportIPAURL else { return }
+        self.pendingImportIPAURL = nil
+        NotificationCenter.default.post(name: AppDelegate.importAppDeepLinkNotification, object: nil, userInfo: [AppDelegate.importAppDeepLinkURLKey: url])
     }
 
     func sceneDidEnterBackground(_ scene: UIScene)
@@ -87,9 +99,37 @@ private extension SceneDelegate
         if context.url.isFileURL
         {
             guard context.url.pathExtension.lowercased() == "ipa" else { return }
-            
-            DispatchQueue.main.async {
-                NotificationCenter.default.post(name: AppDelegate.importAppDeepLinkNotification, object: nil, userInfo: [AppDelegate.importAppDeepLinkURLKey: context.url])
+
+            // Copy the shared .ipa out of its security-scoped location into a
+            // temporary directory we own, so it stays readable while signing.
+            if !context.url.startAccessingSecurityScopedResource() {
+                print("[ALTLog] Failed to access security-scoped resource for imported IPA")
+                return
+            }
+            defer { context.url.stopAccessingSecurityScopedResource() }
+
+            let temporaryDirectory = FileManager.default.uniqueTemporaryURL()
+            do {
+                try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                print("[ALTLog] Failed to create temp directory for imported IPA: \(error)")
+                return
+            }
+
+            let ipa = temporaryDirectory.appendingPathComponent(context.url.lastPathComponent)
+
+            do {
+                try FileManager.default.copyItem(at: context.url, to: ipa)
+            } catch {
+                print("[ALTLog] Failed to copy imported IPA: \(error)")
+                return
+            }
+
+            if UIApplication.shared.applicationState == .active {
+                NotificationCenter.default.post(name: AppDelegate.importAppDeepLinkNotification, object: nil, userInfo: [AppDelegate.importAppDeepLinkURLKey: ipa])
+            } else {
+                // Defer until the scene is active (cold launch) — see sceneDidBecomeActive.
+                self.pendingImportIPAURL = ipa
             }
         }
         else


### PR DESCRIPTION
### Summary

Hardens importing a `.ipa` that is **shared/opened into SideStore** (Share Sheet, Files, "Open in…").

Two issues are fixed:

1. **File became unreadable while signing.** The shared URL is security-scoped and only guaranteed valid for the duration of the open callback. We now copy the `.ipa` into a temporary directory SideStore owns (via `FileManager.default.uniqueTemporaryURL()`) before posting the import notification, so it stays readable through signing/installation.
2. **Imports dropped on cold launch.** If the app/scene wasn't active yet, the import notification was posted into the void. We now stash the URL and post once the app/scene becomes active.

### Changes
- `AltStore/AppDelegate.swift` — `open(_:)` copies the IPA out of security scope; posts immediately when active, otherwise defers via a new `pendingImportIPAURL` flushed in `applicationDidBecomeActive`.
- `AltStore/SceneDelegate.swift` — same handling for `scene(_:openURLContexts:)` / `willConnectTo`, flushed in `sceneDidBecomeActive`.

Both paths add explicit error logging on the copy/temp-dir failure cases. No new dependencies.