### PR TITLE
Add Shortcuts action to install IPA files

### DIFF
--- a/AltStore/Intents/App Intents/AppShortcuts.swift
+++ b/AltStore/Intents/App Intents/AppShortcuts.swift
@@ -12,7 +12,7 @@ import AppIntents
 public struct ShortcutsProvider: AppShortcutsProvider
 {
     public static var appShortcuts: [AppShortcut] {
-        AppShortcut(intent: RefreshAllAppsIntent(), 
+        AppShortcut(intent: RefreshAllAppsIntent(),
                     phrases: [
                         "Refresh \(.applicationName)",
                         "Refresh \(.applicationName) apps",
@@ -21,6 +21,14 @@ public struct ShortcutsProvider: AppShortcutsProvider
                     ],
                     shortTitle: "Refresh All Apps",
                     systemImageName: "arrow.triangle.2.circlepath")
+
+        AppShortcut(intent: InstallIPAIntent(),
+                    phrases: [
+                        "Install IPA with \(.applicationName)",
+                        "Install an IPA with \(.applicationName)",
+                    ],
+                    shortTitle: "Install IPA",
+                    systemImageName: "square.and.arrow.down")
     }
     
     public static var shortcutTileColor: ShortcutTileColor {

--- a/AltStore/Intents/App Intents/RefreshAllAppsIntent.swift
+++ b/AltStore/Intents/App Intents/RefreshAllAppsIntent.swift
@@ -35,6 +35,78 @@ class IntentError: NSError, CustomLocalizedStringResourceConvertible
 }
 
 @available(iOS 17.0, *)
+struct InstallIPAIntent: AppIntent, ProgressReportingIntent
+{
+    static var title: LocalizedStringResource = "Install IPA"
+    static var description = IntentDescription("Installs an IPA file with SideStore.")
+    static var openAppWhenRun = false
+
+    @Parameter(title: "IPA File")
+    var ipaFile: IntentFile
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Install \(\.$ipaFile)")
+    }
+
+    init()
+    {
+        self.progress.completedUnitCount = 0
+        self.progress.totalUnitCount = 1
+    }
+
+    func perform() async throws -> some IntentResult
+    {
+        do
+        {
+            try await Self.startDatabaseIfNeeded()
+
+            let temporaryDirectory = FileManager.default.uniqueTemporaryURL()
+            defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+            try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+
+            let ipaURL = temporaryDirectory.appendingPathComponent("App.ipa")
+            try self.ipaFile.data.write(to: ipaURL)
+
+            let intentProgress = self.progress
+            _ = try await AppManager.shared.installIPA(at: ipaURL) { progress in
+                intentProgress.addChild(progress, withPendingUnitCount: 1)
+            }
+
+            return .result()
+        }
+        catch
+        {
+            let intentError = IntentError(error)
+            throw intentError
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+fileprivate extension InstallIPAIntent
+{
+    static func startDatabaseIfNeeded() async throws
+    {
+        if !DatabaseManager.shared.isStarted
+        {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                DatabaseManager.shared.start { error in
+                    if let error
+                    {
+                        continuation.resume(throwing: error)
+                    }
+                    else
+                    {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@available(iOS 17.0, *)
 extension RefreshAllAppsIntent
 {
     private actor OperationActor
@@ -138,21 +210,7 @@ private extension RefreshAllAppsIntent
 {
     func refreshAllApps() async throws
     {
-        if !DatabaseManager.shared.isStarted
-        {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                DatabaseManager.shared.start { error in
-                    if let error
-                    {
-                        continuation.resume(throwing: error)
-                    }
-                    else
-                    {
-                        continuation.resume()
-                    }
-                }
-            }
-        }
+        try await InstallIPAIntent.startDatabaseIfNeeded()
         
         let context = DatabaseManager.shared.persistentContainer.newBackgroundContext()
         let installedApps = await context.perform { InstalledApp.fetchAppsForRefreshingAll(in: context) }

--- a/AltStore/Managing Apps/AppManager.swift
+++ b/AltStore/Managing Apps/AppManager.swift
@@ -273,7 +273,7 @@ extension AppManager
         return authenticationOperation
     }
     
-    func deactivateApps(for app: ALTApplication, presentingViewController: UIViewController, completion: @escaping (Result<Void, Error>) -> Void)
+    func deactivateApps(for app: ALTApplication, presentingViewController: UIViewController?, completion: @escaping (Result<Void, Error>) -> Void)
     {
         guard !UserDefaults.standard.isAppLimitDisabled, let activeAppsLimit = UserDefaults.standard.activeAppsLimit else { return completion(.success(())) }
         
@@ -309,6 +309,11 @@ extension AppManager
             let availableActiveApps = max(activeAppsLimit - activeAppsCount, 0)
             let requiredActiveSlots = UserDefaults.standard.activeAppLimitIncludesExtensions ? (1 + app.appExtensions.count) : 1
             guard requiredActiveSlots > availableActiveApps else { return completion(.success(())) }
+
+            guard let presentingViewController else {
+                let failureReason = String(format: NSLocalizedString("SideStore needs to deactivate another app before installing %@.", comment: ""), app.name)
+                return completion(.failure(OperationError.forbidden(failureReason: failureReason)))
+            }
             
             let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: UIAlertAction.cancel.title, style: UIAlertAction.cancel.style) { (action) in
@@ -760,6 +765,28 @@ extension AppManager
             
         }
         return group
+    }
+
+    func installIPA(at ipaURL: URL, context: AuthenticatedOperationContext = AuthenticatedOperationContext(), progressHandler: ((Progress) -> Void)? = nil) async throws -> InstalledApp
+    {
+        guard ipaURL.pathExtension.lowercased() == "ipa" else { throw OperationError.invalidApp }
+
+        let temporaryDirectory = FileManager.default.uniqueTemporaryURL()
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let unzippedAppDirectory = temporaryDirectory.appendingPathComponent("App")
+        try FileManager.default.createDirectory(at: unzippedAppDirectory, withIntermediateDirectories: true)
+
+        let unzippedApplicationURL = try FileManager.default.unzipAppBundle(at: ipaURL, toDirectory: unzippedAppDirectory)
+        guard let application = ALTApplication(fileURL: unzippedApplicationURL) else { throw OperationError.invalidApp }
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<InstalledApp, Error>) in
+            let group = self.install(application, presentingViewController: nil, context: context) { result in
+                continuation.resume(with: result)
+            }
+
+            progressHandler?(group.progress)
+        }
     }
     
     @discardableResult
@@ -1385,14 +1412,11 @@ private extension AppManager
                     return
                 }
                                 
-                guard
-                    let app = context.app,
-                    let presentingViewController = context.authenticatedContext.presentingViewController
-                else {
-                    throw OperationError.invalidParameters("AppManager._install.deactivateAppsOperation: self.context.app or context.authenticatedContext.presentingViewController is nil")
+                guard let app = context.app else {
+                    throw OperationError.invalidParameters("AppManager._install.deactivateAppsOperation: self.context.app is nil")
                 }
-                
-                self?.deactivateApps(for: app, presentingViewController: presentingViewController) { result in
+
+                self?.deactivateApps(for: app, presentingViewController: context.authenticatedContext.presentingViewController) { result in
                     switch result
                     {
                     case .failure(let error): group.context.error = error
@@ -2328,4 +2352,3 @@ private extension AppManager {
         }
     }
 }
-


### PR DESCRIPTION
### Changes

-Add a new Shortcuts action to install .ipa files with SideStore
-Add an "Install IPA" App Intent that accepts a file from Shortcuts
-Route IPA installs through SideStore's existing installation pipeline
-Return errors to Shortcuts instead of presenting SideStore UI when user interaction would be required
-Allow app deactivation checks to fail cleanly in non-interactive installs

### Todo before merge
- [x] Test installing an IPA through Shortcuts
