### PR TITLE
GitHub: add triage workflow and labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,168 @@
+# Documentation - https://github.com/actions/labeler
+
+# General Labels
+'Build | Project System':
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/*'
+      - '.github/**/*'
+      - '*.xcconfig'
+      - '**/*.xcconfig'
+      - '*.xcodeproj/*'
+      - '**/*.xcodeproj/*'
+      - 'Makefile'
+      - '.editorconfig'
+      - '.gitignore'
+
+'Dependencies':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'Dependencies/*'
+      - 'Dependencies/**/*'
+      - '.gitmodules'
+
+'Documentation':
+  - changed-files:
+    - any-glob-to-any-file:
+      - '*.md'
+      - '**/*.md'
+      - 'LICENSE'
+
+'GUI/UIKit':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'SideStore/Views/*'
+      - 'SideStore/Views/**/*'
+      - 'AltStore/App Detail/*.swift'
+      - 'AltStore/Browse/*.swift'
+      - 'AltStore/Authentication/*.swift'
+      - 'AltStore/My Apps/*.swift'
+      - 'AltStore/News/*.swift'
+      - 'AltStore/Settings/*.swift'
+      - 'AltStore/Sources/*.swift'
+
+'Resources | Assets':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Resources/*'
+      - 'AltStore/Resources/**/*'
+      - 'AltStore/Base.lproj/*'
+      - 'AltStore/Base.lproj/**/*'
+      - 'AltBackup/Assets.xcassets/*'
+      - 'AltBackup/Assets.xcassets/**/*'
+      - 'AltWidget/Assets.xcassets/*'
+      - 'AltWidget/Assets.xcassets/**/*'
+
+# Tools / Features
+'Backup':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltBackup/*'
+      - 'AltBackup/**/*'
+
+'Widget':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltWidget/*'
+      - 'AltWidget/**/*'
+
+'App Detail':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/App Detail/*'
+      - 'AltStore/App Detail/**/*'
+
+'App IDs':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/App IDs/*'
+      - 'AltStore/App IDs/**/*'
+
+'Authentication':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Authentication/*'
+      - 'AltStore/Authentication/**/*'
+
+'Browse':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Browse/*'
+      - 'AltStore/Browse/**/*'
+
+'Managing Apps':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Managing Apps/*'
+      - 'AltStore/Managing Apps/**/*'
+
+'My Apps':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/My Apps/*'
+      - 'AltStore/My Apps/**/*'
+
+'News':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/News/*'
+      - 'AltStore/News/**/*'
+
+'Settings':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Settings/*'
+      - 'AltStore/Settings/**/*'
+
+'Sources':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Sources/*'
+      - 'AltStore/Sources/**/*'
+
+# Core Components
+'Core':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStoreCore/*'
+      - 'AltStoreCore/**/*'
+
+'Shared':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'Shared/*'
+      - 'Shared/**/*'
+
+'SideStore':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'SideStore/*'
+      - 'SideStore/**/*'
+
+# Other Core Components
+'Operations':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Operations/*'
+      - 'AltStore/Operations/**/*'
+
+'Intents':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Intents/*'
+      - 'AltStore/Intents/**/*'
+
+'Permissions':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/Permissions/*'
+      - 'AltStore/Permissions/**/*'
+
+'App Lifecycle':
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'AltStore/AppDelegate.swift'
+      - 'AltStore/SceneDelegate.swift'
+      - 'AltStore/TabBarController.swift'
+      - 'AltStore/LaunchViewController.swift'
+      - 'AltStore/AppConstants.swift'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,11 @@
-### Changes
+### Description of Changes
+<!-- Brief description or overview on what was changed in the PR -->
 
-<!-- Fill this list with what your PR changes. Example: -->
-- Fix bug
-- Change UI for QOL
+### Rationale behind Changes
+<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
 
-<!-- If your PR is ready to be merged, you can remove this section. -->
-### Todo before merge
+### Suggested Testing Steps
+<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
 
-<!-- Example: -->
-- [x] Finish UI changes
-- [ ] Test
+### Did you use AI to help find, test, or implement this issue or feature?
+<!-- Answer yes or no. If you answer yes, please provide a brief explanation as to how you used it. -->

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,41 @@
+# Runs steps to triage a new Pull Request, such as applying labels.
+name: Pull Request Triage
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    if: github.repository == 'SideStore/SideStore'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label PR based on changed files
+      uses: actions/labeler@v6
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Welcome first-time contributors
+      uses: actions/first-interaction@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        pr-message: |-
+          ## Thank you for submitting a contribution to SideStore!
+
+          As this is your first pull request, [please be aware of our contributing guidelines](https://docs.sidestore.io/docs/contributing).
+
+          Additionally, your pull request will need to be approved by a maintainer before GitHub Actions can run against it. [You can find more information here.](https://github.blog/2021-04-22-github-actions-update-helping-maintainers-combat-bad-actors/)
+
+          Please be patient until this happens. In the meantime, if you'd like to confirm the builds are passing, you have the option of opening a PR on your own fork, just make sure your fork's develop branch is up to date!
+
+    - name: Label First Time Contribution
+      if: |
+        github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+        github.event.pull_request.author_association == 'FIRST_TIMER'
+      run: gh pr edit ${{ github.event.pull_request.number }} --add-label "First Time Contribution"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a PR triage workflow and labeler config to help auto-categorize PRs based on what folders they touch. It also adds a first time welcome comment so they know that we have to approve their GitHub action workflows.