### PR TITLE
Fix - Start SideStore services before Shortcut IPA installs

### DIFF
--- a/AltStore/Intents/App Intents/RefreshAllAppsIntent.swift
+++ b/AltStore/Intents/App Intents/RefreshAllAppsIntent.swift
@@ -45,8 +45,13 @@ struct InstallIPAIntent: AppIntent, ProgressReportingIntent
     @Parameter(title: "IPA File")
     var ipaFile: IntentFile
 
+    @Parameter(title: "Bypass Timeout Error", default: false)
+    var bypassTimeoutError: Bool
+
     static var parameterSummary: some ParameterSummary {
-        Summary("Install \(\.$ipaFile)")
+        Summary("Install \(\.$ipaFile)") {
+            \.$bypassTimeoutError
+        }
     }
 
     init()
@@ -59,20 +64,29 @@ struct InstallIPAIntent: AppIntent, ProgressReportingIntent
     {
         do
         {
-            try await Self.startDatabaseIfNeeded()
+            try await DatabaseManager.shared.start()
             try await Self.startSideStoreServicesIfNeeded()
 
             let temporaryDirectory = FileManager.default.uniqueTemporaryURL()
-            defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
             try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
 
             let ipaURL = temporaryDirectory.appendingPathComponent("App.ipa")
             try self.ipaFile.data.write(to: ipaURL)
 
-            let intentProgress = self.progress
-            _ = try await AppManager.shared.installIPA(at: ipaURL) { progress in
-                intentProgress.addChild(progress, withPendingUnitCount: 1)
+            if self.bypassTimeoutError
+            {
+                Self.installIPABypassingTimeout(at: ipaURL, temporaryDirectory: temporaryDirectory)
+                self.progress.completedUnitCount = 1
+            }
+            else
+            {
+                defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+                let intentProgress = self.progress
+                _ = try await AppManager.shared.installIPA(at: ipaURL) { progress in
+                    intentProgress.addChild(progress, withPendingUnitCount: 1)
+                }
             }
 
             return .result()
@@ -88,6 +102,35 @@ struct InstallIPAIntent: AppIntent, ProgressReportingIntent
 @available(iOS 17.0, *)
 fileprivate extension InstallIPAIntent
 {
+    static func installIPABypassingTimeout(at ipaURL: URL, temporaryDirectory: URL)
+    {
+        BackgroundTaskManager.shared.performExtendedBackgroundTask { (taskResult, taskCompletionHandler) in
+            guard taskResult.error == nil else
+            {
+                try? FileManager.default.removeItem(at: temporaryDirectory)
+                taskCompletionHandler()
+                return
+            }
+
+            Task.detached(priority: .userInitiated) {
+                defer
+                {
+                    try? FileManager.default.removeItem(at: temporaryDirectory)
+                    taskCompletionHandler()
+                }
+
+                do
+                {
+                    _ = try await AppManager.shared.installIPA(at: ipaURL)
+                }
+                catch
+                {
+                    Logger.sideload.error("Failed to install IPA from Shortcuts. \(error.localizedDescription, privacy: .public)")
+                }
+            }
+        }
+    }
+
     static func startSideStoreServicesIfNeeded() async throws
     {
         #if !targetEnvironment(simulator)
@@ -102,46 +145,15 @@ fileprivate extension InstallIPAIntent
 
         let documentsDirectory = FileManager.default.documentsDirectory.absoluteString
         let loggingEnabled = UserDefaults.standard.isMinimuxerConsoleLoggingEnabled
-        let pairingFile = try Self.fetchPairingFile()
+        let pairingFile = try await MainActor.run {
+            try PairingFileManager.shared.loadStoredPairingFile()
+        }
 
         try minimuxerStartWithLogger(pairingFile, documentsDirectory, loggingEnabled)
         startAutoMounter(documentsDirectory)
 
         try await Self.waitForMinimuxer()
         #endif
-    }
-
-    static func fetchPairingFile() throws -> String
-    {
-        let fileManager = FileManager.default
-        let documentsURL = fileManager.documentsDirectory.appendingPathComponent(pairingFileName)
-
-        if fileManager.fileExists(atPath: documentsURL.path),
-           let pairingFile = try? String(contentsOf: documentsURL),
-           !pairingFile.isEmpty
-        {
-            return pairingFile
-        }
-
-        if let url = Bundle.main.url(forResource: "ALTPairingFile", withExtension: "mobiledevicepairing"),
-           fileManager.fileExists(atPath: url.path),
-           let data = fileManager.contents(atPath: url.path),
-           let pairingFile = String(data: data, encoding: .utf8),
-           !pairingFile.isEmpty,
-           !UserDefaults.standard.isPairingReset
-        {
-            return pairingFile
-        }
-
-        if let pairingFile = Bundle.main.object(forInfoDictionaryKey: "ALTPairingFile") as? String,
-           !pairingFile.isEmpty,
-           !pairingFile.contains("insert pairing file here"),
-           !UserDefaults.standard.isPairingReset
-        {
-            return pairingFile
-        }
-
-        throw MinimuxerError.PairingFile
     }
 
     static func waitForMinimuxer() async throws
@@ -157,25 +169,6 @@ fileprivate extension InstallIPAIntent
         }
 
         throw OperationError.unknownUDID
-    }
-
-    static func startDatabaseIfNeeded() async throws
-    {
-        if !DatabaseManager.shared.isStarted
-        {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                DatabaseManager.shared.start { error in
-                    if let error
-                    {
-                        continuation.resume(throwing: error)
-                    }
-                    else
-                    {
-                        continuation.resume()
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -283,7 +276,7 @@ private extension RefreshAllAppsIntent
 {
     func refreshAllApps() async throws
     {
-        try await InstallIPAIntent.startDatabaseIfNeeded()
+        try await DatabaseManager.shared.start()
         
         let context = DatabaseManager.shared.persistentContainer.newBackgroundContext()
         let installedApps = await context.perform { InstalledApp.fetchAppsForRefreshingAll(in: context) }

--- a/AltStore/Intents/App Intents/RefreshAllAppsIntent.swift
+++ b/AltStore/Intents/App Intents/RefreshAllAppsIntent.swift
@@ -7,6 +7,7 @@
 //
 
 import AppIntents
+import Minimuxer
 import WidgetKit
 import AltStoreCore
 
@@ -59,6 +60,7 @@ struct InstallIPAIntent: AppIntent, ProgressReportingIntent
         do
         {
             try await Self.startDatabaseIfNeeded()
+            try await Self.startSideStoreServicesIfNeeded()
 
             let temporaryDirectory = FileManager.default.uniqueTemporaryURL()
             defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
@@ -86,6 +88,77 @@ struct InstallIPAIntent: AppIntent, ProgressReportingIntent
 @available(iOS 17.0, *)
 fileprivate extension InstallIPAIntent
 {
+    static func startSideStoreServicesIfNeeded() async throws
+    {
+        #if !targetEnvironment(simulator)
+        if UserDefaults.standard.enableEMPforWireguard
+        {
+            startEMProxy(bind_addr: AppConstants.Proxy.serverURL)
+        }
+
+        guard !isMinimuxerReady else { return }
+
+        retargetUsbmuxdAddr()
+
+        let documentsDirectory = FileManager.default.documentsDirectory.absoluteString
+        let loggingEnabled = UserDefaults.standard.isMinimuxerConsoleLoggingEnabled
+        let pairingFile = try Self.fetchPairingFile()
+
+        try minimuxerStartWithLogger(pairingFile, documentsDirectory, loggingEnabled)
+        startAutoMounter(documentsDirectory)
+
+        try await Self.waitForMinimuxer()
+        #endif
+    }
+
+    static func fetchPairingFile() throws -> String
+    {
+        let fileManager = FileManager.default
+        let documentsURL = fileManager.documentsDirectory.appendingPathComponent(pairingFileName)
+
+        if fileManager.fileExists(atPath: documentsURL.path),
+           let pairingFile = try? String(contentsOf: documentsURL),
+           !pairingFile.isEmpty
+        {
+            return pairingFile
+        }
+
+        if let url = Bundle.main.url(forResource: "ALTPairingFile", withExtension: "mobiledevicepairing"),
+           fileManager.fileExists(atPath: url.path),
+           let data = fileManager.contents(atPath: url.path),
+           let pairingFile = String(data: data, encoding: .utf8),
+           !pairingFile.isEmpty,
+           !UserDefaults.standard.isPairingReset
+        {
+            return pairingFile
+        }
+
+        if let pairingFile = Bundle.main.object(forInfoDictionaryKey: "ALTPairingFile") as? String,
+           !pairingFile.isEmpty,
+           !pairingFile.contains("insert pairing file here"),
+           !UserDefaults.standard.isPairingReset
+        {
+            return pairingFile
+        }
+
+        throw MinimuxerError.PairingFile
+    }
+
+    static func waitForMinimuxer() async throws
+    {
+        for _ in 0..<10
+        {
+            if isMinimuxerReady
+            {
+                return
+            }
+
+            try await Task.sleep(nanoseconds: 500_000_000)
+        }
+
+        throw OperationError.unknownUDID
+    }
+
     static func startDatabaseIfNeeded() async throws
     {
         if !DatabaseManager.shared.isStarted

--- a/AltStore/Managing Apps/PairingFileManager.swift
+++ b/AltStore/Managing Apps/PairingFileManager.swift
@@ -18,20 +18,36 @@ final class PairingFileManager: NSObject, UIDocumentPickerDelegate {
 
     private var completion: ((URL?) -> Void)?
 
-    func fetchPairingFile(presentingVC: UIViewController) -> String? {
+    func loadStoredPairingFile() throws -> String {
         let fm = FileManager.default
-        let documentsPath = fm.documentsDirectory.appendingPathComponent("/\(Self.pairingFileName)")
+        let documentsPath = fm.documentsDirectory.appendingPathComponent(Self.pairingFileName)
         if fm.fileExists(atPath: documentsPath.path),
            let contents = try? String(contentsOf: documentsPath), !contents.isEmpty {
             return contents
         }
+
         if let url = Bundle.main.url(forResource: "ALTPairingFile", withExtension: "mobiledevicepairing"),
            fm.fileExists(atPath: url.path),
            let data = fm.contents(atPath: url.path),
            let contents = String(data: data, encoding: .utf8),
-           !contents.isEmpty, !UserDefaults.standard.isPairingReset { return contents }
+           !contents.isEmpty, !UserDefaults.standard.isPairingReset {
+            return contents
+        }
+
         if let plistString = Bundle.main.object(forInfoDictionaryKey: "ALTPairingFile") as? String,
-           !plistString.isEmpty, !plistString.contains("insert pairing file here"), !UserDefaults.standard.isPairingReset { return plistString }
+           !plistString.isEmpty,
+           !plistString.contains("insert pairing file here"),
+           !UserDefaults.standard.isPairingReset {
+            return plistString
+        }
+
+        throw MinimuxerError.PairingFile
+    }
+
+    func fetchPairingFile(presentingVC: UIViewController) -> String? {
+        if let pairingFile = try? self.loadStoredPairingFile() {
+            return pairingFile
+        }
 
         presentPairingFileAlert(
             on: presentingVC,


### PR DESCRIPTION
### Description of Changes

- Starts SideStore services before running the Shortcuts IPA install action.
- Initializes EMProxy, Minimuxer, and AutoMounter when needed before calling "AppManager.installIPA".
- Loads the existing pairing file without presenting UI, matching SideStore’s normal launch setup.
- Fixes Shortcut IPA installs failing from a cold launch with “SideStore could not determine this device's UDID.”

Already tested and working.

### Rationale behind Changes

Does fix .ipa installations through shortcuts when SideStore is not running in the background. Now, ipa files can be installed when SideStore is not running in the background (not suspended)

### Suggested Testing Steps

Still need to be implemented a way to install large .ipa files through Shortcuts, because installations currently have a timeout limit.

This PR is still useful for implementing update pipelines for certain apps that are not available in standard AltStore repos.

There is currently a workaround for the Shortcuts timeout limit, which can be useful for installing large .ipa files through Shortcuts. Just google “Apple Shortcuts timeout limit bypass.” The workaround involves using a custom Focus mode and an automation.

Set up the automation like this:

> When this custom Focus mode is triggered, run Shortcut Y.

Then, in Shortcut X, implement your main logic for downloading updates for your desired app. When a new version is detected, store the app in a specific path in the Files app with a simple name, for example:

`/On My iPhone/__<app1>__/app.ipa`

To install the app, Shortcut X should trigger your custom Focus mode. This automatically triggers Shortcut Y if the Focus mode automation is configured correctly.

Shortcut Y should directly install `app.ipa`. Because Shortcut Y is triggered by the Focus mode automation, it should not fail due to the usual Shortcuts timeout limit.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. I used Codex to make the implementation. I reviewed the code and there's not unnecessary code that makes the repo more complex. I also tried the build with gh actions before submitting the PR. Does work well

