### PR TITLE
Fixed legacy dev account app ID limit

### DIFF
--- a/AltStore/Operations/AuthenticationOperation.swift
+++ b/AltStore/Operations/AuthenticationOperation.swift
@@ -266,9 +266,12 @@ final class AuthenticationOperation: ResultOperation<(ALTTeam, ALTCertificate, A
                 let isAppLimitDisabled       = UserDefaults.standard.isAppLimitDisabled
 
                 UserDefaults.standard.activeAppsLimit = nil
+
+                let legacyKey = "isLegacyLapsedAccount_\(team.identifier)"
+                let isLegacyAccount = UserDefaults.standard.bool(forKey: legacyKey)
                 // TODO: @mahee96: is the minimum ver match for ios 13.3.1 check required?
                 //                 if so what is the app limit? As nil app limit specifies unlimited apps?!
-                if team.type == .free//, isMinimumVersionMatching 
+                if team.type == .free && !isLegacyAccount //, isMinimumVersionMatching 
                 {
                     if (!isAppLimitDisabled && isSparseRestorePatched) ||
                         (isAppLimitDisabled && !isSparseRestorePatched)

--- a/AltStore/Operations/FetchProvisioningProfilesOperation.swift
+++ b/AltStore/Operations/FetchProvisioningProfilesOperation.swift
@@ -287,7 +287,14 @@ extension FetchProvisioningProfilesOperation
             do
             {
                 let appIDs = try Result(appIDs, error).get()
+
+                let legacyKey = "isLegacyLapsedAccount_\(team.identifier)"
                 
+                if team.type == .free && appIDs.count > Team.maximumFreeAppIDs
+                {
+                    UserDefaults.standard.set(true, forKey: legacyKey)
+                }
+
                 if let appID = appIDs.first(where: { $0.bundleIdentifier.lowercased() == bundleIdentifier.lowercased() })
                 {
                     Logger.sideload.notice("Using existing App ID \(appID.bundleIdentifier, privacy: .public)")
@@ -301,7 +308,9 @@ extension FetchProvisioningProfilesOperation
                     
                     let sortedExpirationDates = appIDs.compactMap { $0.expirationDate }.sorted(by: { $0 < $1 })
                     
-                    if team.type == .free
+                    let isLegacyAccount = UserDefaults.standard.bool(forKey: legacyKey)
+
+                    if team.type == .free && !isLegacyAccount
                     {
                         if requiredAppIDs > availableAppIDs
                         {


### PR DESCRIPTION
Fixes #1156.

### Description of Changes
Added logic to allow SideStore to differentiate legacy dev accounts from free dev accounts and sign apps outside of the free limits where applicable.

### Rationale behind Changes
This will allow legacy dev accounts to sign new apps when the free limit has already been reached. Legacy account holders such as myself often maintain some paid features even after paid plans lapse, such as allowing more than 10 app IDs to be signed and allowing longer signing windows. Currently, SideStore cannot differentiate a legacy dev from a free dev and applies free dev limits across the board locally, blocking legacy dev accounts from using their retained limits. Without these changes, any new apps that need to be signed have to be signed with another program like iLoader first to sign the app ID, preventing someone like myself to use SideStore untethered.

### Suggested Testing Steps
I have built an .ipa based on my own fork and completed some testing and I was successfully able to sign further app IDs using only SideStore. 

### Did you use AI to help find, test, or implement this issue or feature?
Yes. AI was used to check my work for typos and syntax errors.
