### PR TITLE
fix(connectivity): stabilize Lockdown services on iOS 16 and earlier

### DIFF
--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -188,6 +188,10 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidBecomeActive(_ application: UIApplication)
     {
+        Task {
+            await revalidateMinimuxerConnectivityAfterForeground()
+        }
+
         // Flush any .ipa import that arrived before the app was active (cold launch).
         guard let url = self.pendingImportIPAURL else { return }
         self.pendingImportIPAURL = nil

--- a/SideStore/MinimuxerWrapper.swift
+++ b/SideStore/MinimuxerWrapper.swift
@@ -120,6 +120,12 @@ func minimuxerStart(_ pairingFile: String, mountPath: String) async throws {
     #endif
 }
 
+func revalidateMinimuxerConnectivityAfterForeground() async {
+    #if !targetEnvironment(simulator)
+    await Minimuxer.shared.revalidateConnectivitySessionAfterForeground()
+    #endif
+}
+
 
 func reinitializePairingData(pairingFile: String) async throws {
     defer { debugLog("[SideStore] reinitializePairingData(pairingFile) completed") }


### PR DESCRIPTION
### Description of Changes

This PR addresses the connectivity failures reported in https://github.com/SideStore/SideStore/issues/1377, primarily affecting iOS 16 and earlier devices that use the Lockdown service path.

- Update minimuxer to keep a persistent Lockdown heartbeat session and gate DDI and provisioning-profile operations until the heartbeat completes a successful Marco/Polo exchange.

- Coordinate Lockdown session transitions with in-flight child-service operations, preventing DDI and `misagent` requests from racing heartbeat startup or endpoint replacement.

- Track DDI mount generations so Health Check waits for the current deferred mount instead of observing a transient or stale result.

- Use a heartbeat receive deadline beyond the interval requested by the device to avoid treating the normal heartbeat cadence as a disconnect.

- Recognize the legacy Developer Disk Image response used by older devices (`/Developer` with `DiskImageType=Developer`) in addition to the personalized image schema.

- Revalidate the active Lockdown connectivity session when SideStore returns to the foreground, allowing tunnel or session loss to recover without restarting the app.

- Keep all heartbeat coordination and DDI startup gating scoped to Lockdown. Remote Pairing continues to use its existing RSD service path.

### Rationale behind Changes

On iOS 16 and earlier, SideStore uses Lockdown services for DDI mounting and provisioning-profile management. These operations could start before the heartbeat service was ready or while the active endpoint was being replaced.

This race could cause profile installation to fail with “Unable to Manage Profiles”. It could also make Health Check temporarily report a DDI error before recovering on its own.

The updated minimuxer lifecycle keeps the heartbeat alive, waits for it to become ready before starting dependent Lockdown services, and prevents a session transition from invalidating an in-flight operation.

Remote Pairing/RSD does not require this Lockdown heartbeat coordination and remains on its existing service path.

### Suggested Testing Steps

1. On an iOS 16 or earlier Lockdown device:
   - Open Health Check and leave it visible for at least 60 seconds.
   - Confirm that the DDI status does not intermittently change to an error.
   - Refresh or install an app.
   - Confirm that provisioning-profile installation no longer reports “Unable to Manage Profiles”.

2. Send SideStore to the background and return it to the foreground.
   - Confirm that Health Check and app refresh continue working.
   - Repeat after reconnecting the VPN or tunnel if possible.

3. On an iOS 17 or later Remote Pairing device:
   - Verify Health Check, app installation, and app refresh.
   - Confirm there is no regression in the existing RSD path.

Manual testing completed successfully on:

- iPhone 13 running iOS 16.0.2
- iPhone 13 running iOS 17.5.1

### Did you use AI to help find, test, or implement this issue or feature?

Yes. AI was used to assist with log analysis, implementation review, test-case development, and PR documentation. The final changes were manually reviewed and tested on physical devices.