### PR TITLE
fix(signing): preserve XCTest bundles in imported apps

### DIFF
--- a/SideStore/Core/Operations/PipelineOperations/InstallAppOperation.swift
+++ b/SideStore/Core/Operations/PipelineOperations/InstallAppOperation.swift
@@ -266,41 +266,30 @@ final class InstallAppOperation: BasePipelineOperation<InstallAppOperationContex
     {
         var installedExtensions = Set<InstalledExtension>()
         
-        if let bundle = Bundle(url: resignedAppBundle.fileURL),
-            let directory = bundle.builtInPlugInsURL,
-            let enumerator = FileManager.default.enumerator(
-                at: directory,
-                includingPropertiesForKeys: nil,
-                options: [.skipsSubdirectoryDescendants])
-        {
-            for case let fileURL as URL in enumerator {
-                guard let appExtensionBundle = Bundle(url: fileURL) else { continue }
-                guard let appExtension = ALTApplication(fileURL: appExtensionBundle.bundleURL) else { continue }
-                
-                let parentBundleID = context.bundleIdentifier
-                let resignedParentBundleID = resignedAppBundle.bundleIdentifier
-                
-                let resignedBundleID = appExtension.bundleIdentifier
-                let appExBundleID = resignedBundleID.replacingOccurrences(of: resignedParentBundleID, with: parentBundleID)
-                
-                self.debugLog("""
-                [InstallAppOperation] Extension Bundle Mapping:
-                  • parentBundleID         : \(parentBundleID)
-                  • resignedParentBundleID : \(resignedParentBundleID)
-                  • appExBundleID          : \(appExBundleID)
-                  • resignedAppExBundleID  : \(resignedBundleID)
-                """)
-                
-                let installedExtension = try installedApp.appExtensions
-                                                .first(where: { $0.bundleIdentifier == appExBundleID })
-                                            ?? InstalledExtension(
-                                                resignedAppExtensionBundle: appExtension,
-                                                originalBundleIdentifier: appExBundleID,
-                                                context: backgroundContext
-                                            )
-                installedExtension.update(resignedAppExtensionBundle: appExtension)
-                installedExtensions.insert(installedExtension)
-            }
+        for appExtension in resignedAppBundle.appExtensions {
+            let parentBundleID = context.bundleIdentifier
+            let resignedParentBundleID = resignedAppBundle.bundleIdentifier
+
+            let resignedBundleID = appExtension.bundleIdentifier
+            let appExBundleID = resignedBundleID.replacingOccurrences(of: resignedParentBundleID, with: parentBundleID)
+
+            self.debugLog("""
+            [InstallAppOperation] Extension Bundle Mapping:
+              • parentBundleID         : \(parentBundleID)
+              • resignedParentBundleID : \(resignedParentBundleID)
+              • appExBundleID          : \(appExBundleID)
+              • resignedAppExBundleID  : \(resignedBundleID)
+            """)
+
+            let installedExtension = try installedApp.appExtensions
+                                            .first(where: { $0.bundleIdentifier == appExBundleID })
+                                        ?? InstalledExtension(
+                                            resignedAppExtensionBundle: appExtension,
+                                            originalBundleIdentifier: appExBundleID,
+                                            context: backgroundContext
+                                        )
+            installedExtension.update(resignedAppExtensionBundle: appExtension)
+            installedExtensions.insert(installedExtension)
         }
 
         return installedExtensions

--- a/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift
+++ b/SideStore/Core/Operations/PipelineOperations/ResignAppOperation.swift
@@ -126,9 +126,10 @@ final class ResignAppOperation: BasePipelineOperation<InstallAppOperationContext
         
         if let directory = appBundle.builtInPlugInsURL, let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: nil, options: [.skipsSubdirectoryDescendants]) {
             for case let fileURL as URL in enumerator {
-                // for both sim and device, in debug mode builds, remove the tests bundles (if any)
+                // Only strip SideStore's own debug test products. Imported XCTest runners need their .xctest bundle at runtime.
                 #if DEBUG
-                guard !fileURL.lastPathComponent.lowercased().contains(".xctest") else {
+                let isOwnTestArtifact = targetAppBundle.isAltStoreApp && fileURL.pathExtension.lowercased() == "xctest"
+                if isOwnTestArtifact {
                     // Remove embedded XCTest (+ dSYM) bundle from copied app bundle.
                     try FileManager.default.removeItem(at: fileURL)
                     continue


### PR DESCRIPTION
### Description of Changes

- Limit debug cleanup of `.xctest` bundles to SideStore's own test artifacts.
- Preserve embedded XCTest bundles in imported runner apps during resigning.
- Continue resigning preserved XCTest bundles so imported runners remain launchable.

### Rationale behind Changes

In debug builds, `ResignAppOperation` removed `.xctest` bundles from every app being resigned, not only SideStore itself.

XCTest runner apps such as Appium WebDriverAgent require their embedded `.xctest` bundle at runtime. Removing it during import prevents the runner from launching correctly.

Scoping the cleanup to SideStore's own test artifacts preserves the original cleanup behavior while avoiding modification of imported apps. This fixes LiveContainer/LiveContainer#1489.

### Suggested Testing Steps

1. Build and install a debug version of SideStore.
2. Import an XCTest runner IPA, such as one prepared from Appium WebDriverAgent 15.1.6. need [some modification of the ipa file](https://github.com/altstoreio/AltStore/issues/1692#issuecomment-4830491273), or just unzip the attached one: [WDA15.1.6-AltStore-iOS15+.ipa.zip](https://github.com/user-attachments/files/30651805/WDA15.1.6-AltStore-iOS15%2B.ipa.zip)
3. Before installation, verify that the IPA contains an embedded test bundle such as:

```
Payload/WebDriverAgentRunner-Runner.app/
   └── PlugIns/
         └── WebDriverAgentRunner.xctest/
```

4. Install the IPA through SideStore.
5. Verify that the `.xctest` bundle remains present after resigning and installation.
6. Launch the XCTest runner and confirm that its test plan starts successfully.
7. Confirm that SideStore's own debug XCTest artifacts are still removed when applicable.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. AI was used to help investigate the resigning behavior, prepare the implementation, and refine the PR description. The resulting build and XCTest runner behavior were tested manually.
