### PR TITLE
Develop lc

### DIFF
--- a/AltStore/Core/Model/Source.swift
+++ b/AltStore/Core/Model/Source.swift
@@ -28,9 +28,9 @@ public extension Source
     #else
     
     #if ALPHA
-    static let altStoreSourceURL = URL(string: "https://sidestore.io/apps-v2.json/")!
+    @objc dynamic static let altStoreSourceURL = URL(string: "https://sidestore.io/apps-v2.json/")!
     #else
-    static let altStoreSourceURL = URL(string: "https://sidestore.io/apps-v2.json/")!
+    @objc dynamic static let altStoreSourceURL = URL(string: "https://sidestore.io/apps-v2.json/")!
     #endif
     
     #endif

--- a/AltStore/My Apps/MyAppsViewController.swift
+++ b/AltStore/My Apps/MyAppsViewController.swift
@@ -31,6 +31,7 @@ extension MyAppsViewController
     }
 }
 
+@objc(MyAppsViewController)
 class MyAppsViewController: UICollectionViewController, PeekPopPreviewing
 {
     private let coordinator = NSFileCoordinator()

--- a/Shared/Extensions/Bundle+AltStore.swift
+++ b/Shared/Extensions/Bundle+AltStore.swift
@@ -8,11 +8,17 @@
 
 import Foundation
 
+private extension Bundle {
+    @objc dynamic static let activeBundle: Bundle = Bundle.main
+    @objc dynamic static let storeAppBundleIdentifier = "com.SideStore.SideStore"
+    @objc dynamic static let appbundleIdentifier = "com.SideStore.SideStore"
+}
+
 public extension Bundle
 {
     struct Info
     {
-        public static let activeBundle: Bundle = Bundle.main
+        public static let activeBundle: Bundle = Bundle.activeBundle
         public static let activeBundleURL: URL = activeBundle.bundleURL
         public static let activeBundleVersion: String = {
             let info = activeBundle.infoDictionary
@@ -21,8 +27,8 @@ public extension Bundle
             return NSLocalizedString(String(format: "Version %@%@", version, build), comment: "SideStore Version")
         }()
         public static let activeBundleIdentifier: String = activeBundle.bundleIdentifier!
-        public static let storeAppBundleIdentifier =  "com.SideStore.SideStore"
-        public static let appbundleIdentifier = "com.SideStore.SideStore"
+        public static let storeAppBundleIdentifier = Bundle.storeAppBundleIdentifier
+        public static let appbundleIdentifier = Bundle.appbundleIdentifier
  
         public static let deviceID = "ALTDeviceID"
         public static let serverID = "ALTServerID"
@@ -73,7 +79,7 @@ public extension Bundle
         return self.infoDictionary?[Bundle.Info.appGroups] as? [String] ?? []
     }
     
-    var altstoreAppGroup: String? {        
+    @objc dynamic var altstoreAppGroup: String? {
         let appGroup = self.appGroups.first { $0.contains(Bundle.baseAltStoreAppGroupID) }
         return appGroup
     }

--- a/scripts/ci/generate_release_notes.py
+++ b/scripts/ci/generate_release_notes.py
@@ -9,6 +9,7 @@ IGNORED_AUTHORS = []
 
 TAG_MARKER = "###"
 HEADER_MARKER = "####"
+MAX_RELEASE_NOTE_COMMITS = 100
 
 
 # ----------------------------------------------------------
@@ -49,7 +50,10 @@ def repo_url():
 
 
 def commit_messages(start, end="HEAD"):
-    out = run(f"git log {start}..{end} --pretty=format:%s")
+    out = run(
+        f"git log --max-count={MAX_RELEASE_NOTE_COMMITS} "
+        f"{start}..{end} --pretty=format:%s"
+    )
     return out.splitlines() if out else []
 
 


### PR DESCRIPTION
### Description of Changes
feat: make some fixed variables (and some usages of Bundle.main) dynamic so SideStore can be bundled with other apps


### Rationale behind Changes
- So when building lc+ss we can directly pull the latest nightly ss ipa. Changes are small and should have very little impact on SideStore's performance. SideStore's behavior is not changed.



### Did you use AI to help find, test, or implement this issue or feature?
No