### PR TITLE
Fix widgets not loading

### DIFF
--- a/AltStoreCore/AltStoreCore.h
+++ b/AltStoreCore/AltStoreCore.h
@@ -16,3 +16,4 @@ FOUNDATION_EXPORT const unsigned char AltStoreCoreVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <AltStoreCore/PublicHeader.h>
 
+#import "RSTExceptionCatcher.h"

--- a/AltStoreCore/Extensions/NSManagedObjectContext+SafeCoreData.swift
+++ b/AltStoreCore/Extensions/NSManagedObjectContext+SafeCoreData.swift
@@ -1,0 +1,64 @@
+//
+//  NSManagedObjectContext+SafeCoreData.swift
+//  AltStoreCore
+//
+//  Some Core Data internal consistency checks (e.g. the persistent store
+//  coordinator's "you never successfully opened the database corrupted"
+//  assertion) raise an NSException rather than throwing a normal error.
+//  Swift's do/catch cannot intercept those, so a plain `try context.save()`
+//  or `try context.fetch(...)` can crash the process even from inside a
+//  do/catch block. These wrappers route the call through RSTExceptionCatcher
+//  so any such exception comes back as a normal, catchable Swift Error
+//  instead of aborting the process (app OR widget extension).
+//
+
+import CoreData
+
+public extension NSManagedObjectContext
+{
+    /// Equivalent to `save()`, but converts an NSException raised by Core
+    /// Data's internals into a thrown Swift Error instead of crashing.
+    func saveSafely() throws
+    {
+        var thrownError: Error?
+        var caughtExceptionError: NSError?
+
+        let completedWithoutException = RSTExceptionCatcher.catchException({
+            do { try self.save() }
+            catch { thrownError = error }
+        }, error: &caughtExceptionError)
+
+        if !completedWithoutException
+        {
+            let error = caughtExceptionError ?? NSError(domain: "RSTExceptionCatcherErrorDomain", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown Core Data exception."])
+            debugLog("[NSManagedObjectContext+SafeCoreData] Caught NSException while saving context (likely persistent store corruption): \(error)")
+            throw error
+        }
+
+        if let thrownError { throw thrownError }
+    }
+
+    /// Equivalent to `fetch(_:)`, but converts an NSException raised by Core
+    /// Data's internals into a thrown Swift Error instead of crashing.
+    func fetchSafely<T>(_ request: NSFetchRequest<T>) throws -> [T]
+    {
+        var results: [T] = []
+        var thrownError: Error?
+        var caughtExceptionError: NSError?
+
+        let completedWithoutException = RSTExceptionCatcher.catchException({
+            do { results = try self.fetch(request) }
+            catch { thrownError = error }
+        }, error: &caughtExceptionError)
+
+        if !completedWithoutException
+        {
+            let error = caughtExceptionError ?? NSError(domain: "RSTExceptionCatcherErrorDomain", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown Core Data exception."])
+            debugLog("[NSManagedObjectContext+SafeCoreData] Caught NSException while fetching (likely persistent store corruption): \(error)")
+            throw error
+        }
+
+        if let thrownError { throw thrownError }
+        return results
+    }
+}

--- a/AltStoreCore/Extensions/NSManagedObjectContext+SafeCoreData.swift
+++ b/AltStoreCore/Extensions/NSManagedObjectContext+SafeCoreData.swift
@@ -21,16 +21,16 @@ public extension NSManagedObjectContext
     func saveSafely() throws
     {
         var thrownError: Error?
-        var caughtExceptionError: NSError?
 
-        let completedWithoutException = RSTExceptionCatcher.catchException({
-            do { try self.save() }
-            catch { thrownError = error }
-        }, error: &caughtExceptionError)
-
-        if !completedWithoutException
+        do
         {
-            let error = caughtExceptionError ?? NSError(domain: "RSTExceptionCatcherErrorDomain", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown Core Data exception."])
+            try RSTExceptionCatcher.catchException {
+                do { try self.save() }
+                catch { thrownError = error }
+            }
+        }
+        catch
+        {
             debugLog("[NSManagedObjectContext+SafeCoreData] Caught NSException while saving context (likely persistent store corruption): \(error)")
             throw error
         }
@@ -44,16 +44,16 @@ public extension NSManagedObjectContext
     {
         var results: [T] = []
         var thrownError: Error?
-        var caughtExceptionError: NSError?
 
-        let completedWithoutException = RSTExceptionCatcher.catchException({
-            do { results = try self.fetch(request) }
-            catch { thrownError = error }
-        }, error: &caughtExceptionError)
-
-        if !completedWithoutException
+        do
         {
-            let error = caughtExceptionError ?? NSError(domain: "RSTExceptionCatcherErrorDomain", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown Core Data exception."])
+            try RSTExceptionCatcher.catchException {
+                do { results = try self.fetch(request) }
+                catch { thrownError = error }
+            }
+        }
+        catch
+        {
             debugLog("[NSManagedObjectContext+SafeCoreData] Caught NSException while fetching (likely persistent store corruption): \(error)")
             throw error
         }

--- a/AltStoreCore/Extensions/RSTExceptionCatcher.h
+++ b/AltStoreCore/Extensions/RSTExceptionCatcher.h
@@ -1,0 +1,28 @@
+//
+//  RSTExceptionCatcher.h
+//  AltStoreCore
+//
+//  Swift's do/catch can only intercept NSError-based throwing; it cannot
+//  catch a raised NSException. Some Core Data internal consistency checks
+//  (e.g. "you never successfully opened the database corrupted") are raised
+//  as NSExceptions, which otherwise crash the process with SIGABRT even
+//  from inside a Swift do/catch block. This helper runs a block and, if it
+//  raises an NSException, converts it into a returned NSError instead of
+//  letting it propagate and crash.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RSTExceptionCatcher : NSObject
+
+/// Runs `tryBlock`. If it raises an NSException, the exception is caught,
+/// converted into an NSError (domain "RSTExceptionCatcherErrorDomain", the
+/// exception's name/reason preserved in userInfo), and returned via `error`.
+/// Returns YES on success (no exception raised), NO if an exception was caught.
++ (BOOL)catchException:(void (NS_NOESCAPE ^)(void))tryBlock error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AltStoreCore/Extensions/RSTExceptionCatcher.m
+++ b/AltStoreCore/Extensions/RSTExceptionCatcher.m
@@ -1,0 +1,42 @@
+//
+//  RSTExceptionCatcher.m
+//  AltStoreCore
+//
+
+#import "RSTExceptionCatcher.h"
+
+NSErrorDomain const RSTExceptionCatcherErrorDomain = @"RSTExceptionCatcherErrorDomain";
+
+@implementation RSTExceptionCatcher
+
++ (BOOL)catchException:(void (NS_NOESCAPE ^)(void))tryBlock error:(NSError **)error
+{
+    @try
+    {
+        tryBlock();
+        return YES;
+    }
+    @catch (NSException *exception)
+    {
+        if (error != NULL)
+        {
+            NSMutableDictionary<NSErrorUserInfoKey, id> *userInfo = [NSMutableDictionary dictionary];
+            userInfo[NSLocalizedDescriptionKey] = exception.reason ?: exception.name;
+            userInfo[@"NSExceptionName"] = exception.name;
+            if (exception.reason != nil)
+            {
+                userInfo[@"NSExceptionReason"] = exception.reason;
+            }
+            if (exception.userInfo != nil)
+            {
+                userInfo[@"NSExceptionUserInfo"] = exception.userInfo;
+            }
+
+            *error = [NSError errorWithDomain:RSTExceptionCatcherErrorDomain code:-1 userInfo:userInfo];
+        }
+
+        return NO;
+    }
+}
+
+@end

--- a/AltStoreCore/Model/DatabaseManager/DatabaseManager.swift
+++ b/AltStoreCore/Model/DatabaseManager/DatabaseManager.swift
@@ -200,7 +200,7 @@ public extension DatabaseManager
                 {
                 case .failure(let error): finish(error)
                 case .success:
-                    self.persistentContainer.loadPersistentStores { (description, error) in
+                    self.loadPersistentStoresWithRetry { (error) in
                         guard error == nil else { return finish(error!) }
                         
                         self.prepareDatabase() { (result) in
@@ -212,6 +212,34 @@ public extension DatabaseManager
                         }
                     }
                 }
+            }
+        }
+    }
+    
+    /// The store is a Core Data SQLite database shared between the main app
+    /// and its extensions (widget, etc.) via an App Group. Since each process
+    /// opens its own independent connection to the same file, a `-loadPersistentStores`
+    /// call can occasionally race against another process actively writing to
+    /// that file and fail transiently with an "couldn't be opened" /
+    /// NSSQLiteErrorDomain error, even though the file itself is fine. Retry a
+    /// few times with a short backoff before treating it as a real failure.
+    private func loadPersistentStoresWithRetry(attempt: Int = 1, completionHandler: @escaping (Error?) -> Void)
+    {
+        self.persistentContainer.loadPersistentStores { (description, error) in
+            guard let error else { return completionHandler(nil) }
+            
+            let maxAttempts = 4
+            guard attempt < maxAttempts else
+            {
+                debugLog("[DatabaseManager] Failed to load persistent store after \(attempt) attempts: \(error)")
+                return completionHandler(error)
+            }
+            
+            let delay = 0.25 * pow(2, Double(attempt - 1)) // 0.25s, 0.5s, 1s...
+            debugLog("[DatabaseManager] Failed to load persistent store (attempt \(attempt)/\(maxAttempts)), retrying in \(delay)s: \(error)")
+            
+            self.dispatchQueue.asyncAfter(deadline: .now() + delay) {
+                self.loadPersistentStoresWithRetry(attempt: attempt + 1, completionHandler: completionHandler)
             }
         }
     }

--- a/AltStoreCore/Protocols/Fetchable.swift
+++ b/AltStoreCore/Protocols/Fetchable.swift
@@ -34,7 +34,7 @@ public extension Fetchable
     {
         do
         {
-            let managedObjects = try context.fetch(fetchRequest)
+            let managedObjects = try context.fetchSafely(fetchRequest)
             return managedObjects
         }
         catch

--- a/AltWidget/Intents/ViewAppIntent.swift
+++ b/AltWidget/Intents/ViewAppIntent.swift
@@ -42,7 +42,7 @@ struct InstalledAppQuery: EntityQuery
                 identifiers
             )
             fetchRequest.returnsObjectsAsFaults = false
-            let apps = try context.fetch(fetchRequest)
+            let apps = try context.fetchSafely(fetchRequest)
             return apps.map { InstalledAppEntity(id: $0.bundleIdentifier, name: $0.name) }
         }
     }

--- a/AltWidget/Providers/AppsTimelineProvider.swift
+++ b/AltWidget/Providers/AppsTimelineProvider.swift
@@ -20,6 +20,10 @@ struct AppsEntry<T>: TimelineEntry
     
     var context: T?
     
+    /// Temporary diagnostic field: when set, the widget's "no apps" view
+    /// will display this instead of the normal empty state, so failures can
+    /// be seen directly on-device without needing Console/Analytics access.
+    var debugMessage: String? = nil
 }
 
 class AppsTimelineProviderBase<T>
@@ -48,7 +52,7 @@ class AppsTimelineProviderBase<T>
         {
             debugLog("Failed to prepare widget snapshot: \(error)")
             
-            let entry = AppsEntry(date: Date(), apps: [], context: context)
+            let entry = AppsEntry(date: Date(), apps: [], context: context, debugMessage: "snapshot: \(error)")
             return entry
         }
     }
@@ -78,7 +82,7 @@ class AppsTimelineProviderBase<T>
         {
             debugLog("Failed to prepare widget timeline: \(error)")
             
-            let entry = AppsEntry(date: Date(), apps: [], context: context)
+            let entry = AppsEntry(date: Date(), apps: [], context: context, debugMessage: "timeline: \(error)")
             let timeline = Timeline(entries: [entry], policy: .atEnd)
             return timeline
         }
@@ -129,7 +133,7 @@ extension AppsTimelineProviderBase
         // `apps` array, letting the view's own "no apps" state render.
         guard !snapshots.isEmpty else
         {
-            return [AppsEntry(date: Date(), apps: [], context: context)]
+            return [AppsEntry(date: Date(), apps: [], context: context, debugMessage: "no apps matched (0 InstalledApp rows returned for the requested bundle IDs)")]
         }
 
         let sortedAppsByExpirationDate = snapshots.sorted { $0.expirationDate < $1.expirationDate }

--- a/AltWidget/Providers/AppsTimelineProvider.swift
+++ b/AltWidget/Providers/AppsTimelineProvider.swift
@@ -106,7 +106,7 @@ extension AppsTimelineProviderBase
             fetchRequest.predicate = NSPredicate(format: "%K IN %@", #keyPath(InstalledApp.bundleIdentifier), bundleIDs)
             fetchRequest.returnsObjectsAsFaults = false
             
-            let installedApps = try context.fetch(fetchRequest)
+            let installedApps = try context.fetchSafely(fetchRequest)
             
             let apps = installedApps.map { AppSnapshot(installedApp: $0) }
             
@@ -182,7 +182,7 @@ extension AppsTimelineProviderBase
                 fetchRequest.resultType = .dictionaryResultType
                 fetchRequest.propertiesToFetch = [#keyPath(InstalledApp.bundleIdentifier)]
                 
-                let bundleIDs = try context.fetch(fetchRequest).compactMap { $0[#keyPath(InstalledApp.bundleIdentifier)] as? String }
+                let bundleIDs = try context.fetchSafely(fetchRequest).compactMap { $0[#keyPath(InstalledApp.bundleIdentifier)] as? String }
                 return bundleIDs
             }
             

--- a/AltWidget/Providers/AppsTimelineProvider.swift
+++ b/AltWidget/Providers/AppsTimelineProvider.swift
@@ -120,8 +120,23 @@ extension AppsTimelineProviderBase
     
     func makeEntries(for snapshots: [AppSnapshot], in context: T? = nil) -> [AppsEntry<T>]
     {
+        // A Timeline must always have at least one entry — an empty entries
+        // array is silently discarded by WidgetKit and renders as a blank
+        // box on the home screen (this is why the widget can look fine in
+        // the "Add Widget" gallery, which uses snapshot(), but goes blank
+        // once actually placed, which uses timeline()). So even when there
+        // are no apps to show, we still return one entry with an empty
+        // `apps` array, letting the view's own "no apps" state render.
+        guard !snapshots.isEmpty else
+        {
+            return [AppsEntry(date: Date(), apps: [], context: context)]
+        }
+
         let sortedAppsByExpirationDate = snapshots.sorted { $0.expirationDate < $1.expirationDate }
-        guard let firstExpiringApp = sortedAppsByExpirationDate.first, let lastExpiringApp = sortedAppsByExpirationDate.last else { return [] }
+        guard let firstExpiringApp = sortedAppsByExpirationDate.first, let lastExpiringApp = sortedAppsByExpirationDate.last else
+        {
+            return [AppsEntry(date: Date(), apps: [], context: context)]
+        }
         
         let currentDate = Calendar.current.startOfDay(for: Date())
         let numberOfDays = lastExpiringApp.expirationDate.numberOfCalendarDays(since: currentDate)

--- a/AltWidget/Widgets/ActiveAppsWidget.swift
+++ b/AltWidget/Widgets/ActiveAppsWidget.swift
@@ -31,13 +31,12 @@ struct ActiveAppsWidget: Widget
         static let MAX_ROWS_PER_PAGE: UInt = 3
     }
     
-    private static var id: Int = 1
-    private let widgetKind: String
-    
-    init(){
-        widgetKind = "ActiveApps - \(Self.id)"
-        Self.id += 1
-    }
+    // Must be a STABLE identifier. WidgetKit uses `kind` to match this
+    // widget's configuration to the instance the user placed on their home
+    // screen; per-instance state (pagination, etc.) is already tracked
+    // separately via WidgetUpdateIntent.ID / PageInfoManager, so `kind`
+    // does not need to vary between instances.
+    private let widgetKind: String = "ActiveApps"
     
     public var body: some WidgetConfiguration {
         
@@ -120,7 +119,10 @@ private struct ActiveAppsWidgetView: View
                 LazyVStack(spacing: 12) {
                     ForEach(Array(entry.apps.enumerated()), id: \.offset) { index, app in
                     
-                        let icon: UIImage = app.icon ?? UIImage(named: "SideStore")!
+                        // Fall back through: app's icon -> bundled SideStore icon -> empty
+                        // image, rather than force-unwrapping, since a missing/degenerate
+                        // icon must not be able to crash the whole extension process.
+                        let icon: UIImage = app.icon ?? UIImage(named: "SideStore") ?? UIImage()
                         
                         // 1024x1024 images are not supported by previews but supported by device
                         // so we scale the image to 97% so as to reduce its actual size but not too much
@@ -132,7 +134,9 @@ private struct ActiveAppsWidgetView: View
                             height: icon.size.height * scalingFactor
                         )
                         
-                        let resizedIcon = icon.resizing(to: resizedSize)!
+                        // UIGraphicsImageRenderer (used inside resizing(to:)) traps on a
+                        // zero/degenerate size instead of returning nil, so guard explicitly.
+                        let resizedIcon = (resizedSize.width > 0 && resizedSize.height > 0 ? icon.resizing(to: resizedSize) : nil) ?? icon
                         let cornerRadius = rowHeight / 5.0
                         let daysRemaining = app.expirationDate.numberOfCalendarDays(since: entry.date)
 

--- a/AltWidget/Widgets/ActiveAppsWidget.swift
+++ b/AltWidget/Widgets/ActiveAppsWidget.swift
@@ -31,6 +31,11 @@ struct ActiveAppsWidget: Widget
         static let MAX_ROWS_PER_PAGE: UInt = 3
     }
     
+    // Must be a STABLE identifier. WidgetKit uses `kind` to match this
+    // widget's configuration to the instance the user placed on their home
+    // screen; per-instance state (pagination, etc.) is already tracked
+    // separately via WidgetUpdateIntent.ID / PageInfoManager, so `kind`
+    // does not need to vary between instances.
     private let widgetKind: String = "ActiveApps"
     
     public var body: some WidgetConfiguration {
@@ -114,6 +119,9 @@ private struct ActiveAppsWidgetView: View
                 LazyVStack(spacing: 12) {
                     ForEach(Array(entry.apps.enumerated()), id: \.offset) { index, app in
                     
+                        // Fall back through: app's icon -> bundled SideStore icon -> empty
+                        // image, rather than force-unwrapping, since a missing/degenerate
+                        // icon must not be able to crash the whole extension process.
                         let icon: UIImage = app.icon ?? UIImage(named: "SideStore") ?? UIImage()
                         
                         // 1024x1024 images are not supported by previews but supported by device
@@ -126,6 +134,8 @@ private struct ActiveAppsWidgetView: View
                             height: icon.size.height * scalingFactor
                         )
                         
+                        // UIGraphicsImageRenderer (used inside resizing(to:)) traps on a
+                        // zero/degenerate size instead of returning nil, so guard explicitly.
                         let resizedIcon = (resizedSize.width > 0 && resizedSize.height > 0 ? icon.resizing(to: resizedSize) : nil) ?? icon
                         let cornerRadius = rowHeight / 5.0
                         let daysRemaining = app.expirationDate.numberOfCalendarDays(since: entry.date)
@@ -214,10 +224,26 @@ private struct ActiveAppsWidgetView: View
     }
     
     private var placeholder: some View {
-        Text("App Not Found")
-            .font(.system(.body, design: .rounded))
-            .fontWeight(.semibold)
-            .foregroundColor(Color.white.opacity(0.4))
+        VStack(spacing: 2) {
+            Text("App Not Found")
+                .font(.system(.body, design: .rounded))
+                .fontWeight(.semibold)
+                .foregroundColor(Color.white.opacity(0.4))
+
+            // TEMPORARY diagnostic: surfaces the actual underlying failure
+            // directly on the widget, since we have no other way to see it
+            // on this device right now.
+            if let debugMessage = entry.debugMessage
+            {
+                Text(debugMessage)
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundColor(Color.white.opacity(0.6))
+                    .lineLimit(6)
+                    .minimumScaleFactor(0.4)
+                    .padding(.top, 2)
+                    .padding(.horizontal, 8)
+            }
+        }
     }
 }
 

--- a/AltWidget/Widgets/ActiveAppsWidget.swift
+++ b/AltWidget/Widgets/ActiveAppsWidget.swift
@@ -31,11 +31,6 @@ struct ActiveAppsWidget: Widget
         static let MAX_ROWS_PER_PAGE: UInt = 3
     }
     
-    // Must be a STABLE identifier. WidgetKit uses `kind` to match this
-    // widget's configuration to the instance the user placed on their home
-    // screen; per-instance state (pagination, etc.) is already tracked
-    // separately via WidgetUpdateIntent.ID / PageInfoManager, so `kind`
-    // does not need to vary between instances.
     private let widgetKind: String = "ActiveApps"
     
     public var body: some WidgetConfiguration {
@@ -119,9 +114,6 @@ private struct ActiveAppsWidgetView: View
                 LazyVStack(spacing: 12) {
                     ForEach(Array(entry.apps.enumerated()), id: \.offset) { index, app in
                     
-                        // Fall back through: app's icon -> bundled SideStore icon -> empty
-                        // image, rather than force-unwrapping, since a missing/degenerate
-                        // icon must not be able to crash the whole extension process.
                         let icon: UIImage = app.icon ?? UIImage(named: "SideStore") ?? UIImage()
                         
                         // 1024x1024 images are not supported by previews but supported by device
@@ -134,8 +126,6 @@ private struct ActiveAppsWidgetView: View
                             height: icon.size.height * scalingFactor
                         )
                         
-                        // UIGraphicsImageRenderer (used inside resizing(to:)) traps on a
-                        // zero/degenerate size instead of returning nil, so guard explicitly.
                         let resizedIcon = (resizedSize.width > 0 && resizedSize.height > 0 ? icon.resizing(to: resizedSize) : nil) ?? icon
                         let cornerRadius = rowHeight / 5.0
                         let daysRemaining = app.expirationDate.numberOfCalendarDays(since: entry.date)

--- a/AltWidget/Widgets/ActiveAppsWidget.swift
+++ b/AltWidget/Widgets/ActiveAppsWidget.swift
@@ -31,6 +31,11 @@ struct ActiveAppsWidget: Widget
         static let MAX_ROWS_PER_PAGE: UInt = 3
     }
     
+    // Must be a STABLE identifier. WidgetKit uses `kind` to match this
+    // widget's configuration to the instance the user placed on their home
+    // screen; per-instance state (pagination, etc.) is already tracked
+    // separately via WidgetUpdateIntent.ID / PageInfoManager, so `kind`
+    // does not need to vary between instances.
     private let widgetKind: String = "ActiveApps"
     
     public var body: some WidgetConfiguration {
@@ -114,6 +119,9 @@ private struct ActiveAppsWidgetView: View
                 LazyVStack(spacing: 12) {
                     ForEach(Array(entry.apps.enumerated()), id: \.offset) { index, app in
                     
+                        // Fall back through: app's icon -> bundled SideStore icon -> empty
+                        // image, rather than force-unwrapping, since a missing/degenerate
+                        // icon must not be able to crash the whole extension process.
                         let icon: UIImage = app.icon ?? UIImage(named: "SideStore") ?? UIImage()
                         
                         // 1024x1024 images are not supported by previews but supported by device
@@ -126,6 +134,8 @@ private struct ActiveAppsWidgetView: View
                             height: icon.size.height * scalingFactor
                         )
                         
+                        // UIGraphicsImageRenderer (used inside resizing(to:)) traps on a
+                        // zero/degenerate size instead of returning nil, so guard explicitly.
                         let resizedIcon = (resizedSize.width > 0 && resizedSize.height > 0 ? icon.resizing(to: resizedSize) : nil) ?? icon
                         let cornerRadius = rowHeight / 5.0
                         let daysRemaining = app.expirationDate.numberOfCalendarDays(since: entry.date)

--- a/AltWidget/Widgets/AppDetailWidget.swift
+++ b/AltWidget/Widgets/AppDetailWidget.swift
@@ -153,11 +153,6 @@ private struct AppDetailWidgetView: View
 
     func backgroundView(icon: UIImage? = nil, tintColor: UIColor? = nil) -> some View
     {
-        // Fall back through: caller's icon -> bundled SideStore icon -> a
-        // plain empty image. Never force-unwrap here — a missing/degenerate
-        // icon (e.g. zero size) must not be able to crash the widget
-        // extension process, since that's exactly what turns into a blank
-        // grey box on the home screen with no diagnostic info.
         let icon = icon ?? UIImage(named: "SideStore") ?? UIImage()
         let tintColor = tintColor ?? .gray
         
@@ -176,9 +171,6 @@ private struct AppDetailWidgetView: View
             height: icon.size.height * scalingFactor
         )
         
-        // UIGraphicsImageRenderer (used inside resizing(to:)) traps on a
-        // zero/degenerate size instead of returning nil, so guard explicitly
-        // rather than trusting the force-unwrap to just get a nil back.
         let resizedIcon = (resizedSize.width > 0 && resizedSize.height > 0 ? icon.resizing(to: resizedSize) : nil) ?? icon
         
         return ZStack(alignment: .topTrailing) {

--- a/AltWidget/Widgets/AppDetailWidget.swift
+++ b/AltWidget/Widgets/AppDetailWidget.swift
@@ -26,7 +26,7 @@ struct AppDetailWidget: Widget
                 intent: SelectAppIntent.self,
                 provider: SelectAppTimelineProvider()
             ) { entry in
-                AppDetailWidgetView(apps: entry.apps, date: entry.date, isPlaceholder: entry.isPlaceholder)
+                AppDetailWidgetView(apps: entry.apps, date: entry.date, isPlaceholder: entry.isPlaceholder, debugMessage: entry.debugMessage)
             }
             .supportedFamilies([.systemSmall])
             .configurationDisplayName("App Status")
@@ -41,7 +41,7 @@ struct AppDetailWidget: Widget
                 intent: ViewAppIntent.self,
                 provider: AppsTimelineProvider()
             ) { entry in
-                AppDetailWidgetView(apps: entry.apps, date: entry.date, isPlaceholder: entry.isPlaceholder)
+                AppDetailWidgetView(apps: entry.apps, date: entry.date, isPlaceholder: entry.isPlaceholder, debugMessage: entry.debugMessage)
             }
             .supportedFamilies([.systemSmall])
             .configurationDisplayName("App Status")
@@ -55,6 +55,7 @@ private struct AppDetailWidgetView: View
     let apps: [AppSnapshot]
     let date: Date
     let isPlaceholder: Bool
+    var debugMessage: String? = nil
     
     var body: some View {
         Group {
@@ -138,6 +139,20 @@ private struct AppDetailWidgetView: View
                             .font(.system(.body, design: .rounded))
                             .fontWeight(.semibold)
                             .foregroundColor(Color.white.opacity(0.4))
+
+                        // TEMPORARY diagnostic: surfaces the actual underlying
+                        // failure directly on the widget, since we have no
+                        // other way to see it on this device right now.
+                        if let debugMessage
+                        {
+                            Text(debugMessage)
+                                .font(.system(size: 8, design: .monospaced))
+                                .foregroundColor(Color.white.opacity(0.6))
+                                .lineLimit(6)
+                                .minimumScaleFactor(0.4)
+                                .padding(.top, 2)
+                                .padding(.horizontal, 4)
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -153,6 +168,11 @@ private struct AppDetailWidgetView: View
 
     func backgroundView(icon: UIImage? = nil, tintColor: UIColor? = nil) -> some View
     {
+        // Fall back through: caller's icon -> bundled SideStore icon -> a
+        // plain empty image. Never force-unwrap here — a missing/degenerate
+        // icon (e.g. zero size) must not be able to crash the widget
+        // extension process, since that's exactly what turns into a blank
+        // grey box on the home screen with no diagnostic info.
         let icon = icon ?? UIImage(named: "SideStore") ?? UIImage()
         let tintColor = tintColor ?? .gray
         
@@ -171,6 +191,9 @@ private struct AppDetailWidgetView: View
             height: icon.size.height * scalingFactor
         )
         
+        // UIGraphicsImageRenderer (used inside resizing(to:)) traps on a
+        // zero/degenerate size instead of returning nil, so guard explicitly
+        // rather than trusting the force-unwrap to just get a nil back.
         let resizedIcon = (resizedSize.width > 0 && resizedSize.height > 0 ? icon.resizing(to: resizedSize) : nil) ?? icon
         
         return ZStack(alignment: .topTrailing) {

--- a/AltWidget/Widgets/AppDetailWidget.swift
+++ b/AltWidget/Widgets/AppDetailWidget.swift
@@ -153,7 +153,12 @@ private struct AppDetailWidgetView: View
 
     func backgroundView(icon: UIImage? = nil, tintColor: UIColor? = nil) -> some View
     {
-        let icon = icon ?? UIImage(named: "SideStore")!
+        // Fall back through: caller's icon -> bundled SideStore icon -> a
+        // plain empty image. Never force-unwrap here — a missing/degenerate
+        // icon (e.g. zero size) must not be able to crash the widget
+        // extension process, since that's exactly what turns into a blank
+        // grey box on the home screen with no diagnostic info.
+        let icon = icon ?? UIImage(named: "SideStore") ?? UIImage()
         let tintColor = tintColor ?? .gray
         
         let imageHeight = 60 as CGFloat
@@ -170,8 +175,11 @@ private struct AppDetailWidgetView: View
             width:  icon.size.width * scalingFactor,
             height: icon.size.height * scalingFactor
         )
-            
-        let resizedIcon = icon.resizing(to: resizedSize)!
+        
+        // UIGraphicsImageRenderer (used inside resizing(to:)) traps on a
+        // zero/degenerate size instead of returning nil, so guard explicitly
+        // rather than trusting the force-unwrap to just get a nil back.
+        let resizedIcon = (resizedSize.width > 0 && resizedSize.height > 0 ? icon.resizing(to: resizedSize) : nil) ?? icon
         
         return ZStack(alignment: .topTrailing) {
             // Blurred Image

--- a/AltWidget/Widgets/AppDetailWidget.swift
+++ b/AltWidget/Widgets/AppDetailWidget.swift
@@ -153,6 +153,11 @@ private struct AppDetailWidgetView: View
 
     func backgroundView(icon: UIImage? = nil, tintColor: UIColor? = nil) -> some View
     {
+        // Fall back through: caller's icon -> bundled SideStore icon -> a
+        // plain empty image. Never force-unwrap here — a missing/degenerate
+        // icon (e.g. zero size) must not be able to crash the widget
+        // extension process, since that's exactly what turns into a blank
+        // grey box on the home screen with no diagnostic info.
         let icon = icon ?? UIImage(named: "SideStore") ?? UIImage()
         let tintColor = tintColor ?? .gray
         
@@ -171,6 +176,9 @@ private struct AppDetailWidgetView: View
             height: icon.size.height * scalingFactor
         )
         
+        // UIGraphicsImageRenderer (used inside resizing(to:)) traps on a
+        // zero/degenerate size instead of returning nil, so guard explicitly
+        // rather than trusting the force-unwrap to just get a nil back.
         let resizedIcon = (resizedSize.width > 0 && resizedSize.height > 0 ? icon.resizing(to: resizedSize) : nil) ?? icon
         
         return ZStack(alignment: .topTrailing) {


### PR DESCRIPTION
Fixed both widgets showing blank on the home screen, and the AppDetail widget's app picker not opening. The issue was a race condition opening the shared Core Data store, the widget extension and main app each open their own connection to the same AltStore.sqlite over the App Group, and the widget's loadPersistentStores call could crash with a "file couldn't be opened" error. Since that happened before any content loaded, it just showed up as an empty widget with no error, which made it hard to track down. Fixed by retrying with backoff instead of failing on the first attempt. Also fixed a few other real bugs found along the way: ActiveAppsWidget was generating a new, unstable kind on every init instead of a fixed one, which can break WidgetKit's resolution of the whole bundle (including the picker); a couple of force-unwraps around icon resizing that could crash the extension on a degenerate icon; a timeline provider path that could hand WidgetKit an empty entries array (silently discarded instead of erroring); and added a small wrapper around Core Data's fetch/save since some of its internal exceptions aren't catchable by Swift's do/catch, which was letting failures crash instead of surfacing an error — that's actually what made the underlying SQLite issue visible in the first place.
