### PR TITLE
fix: TreeMap.remove() can loop forever - delete fix-up gets the wrong parent

### DIFF
--- a/SideStore/Tests/UnitTests/datastructures/TreeMapTests.swift
+++ b/SideStore/Tests/UnitTests/datastructures/TreeMapTests.swift
@@ -167,12 +167,15 @@ class TreeMapTests: XCTestCase {
             XCTAssertNil(map[2])
             XCTAssertEqual(map.keys, [1, 3, 4, 5, 6])
             XCTAssertEqual(map.count, 5)
+            XCTAssertNil(map.firstRedBlackInvariantViolation())
         }
     }
 
     func testEverySingleRemovalKeepsMapConsistent() {
-        // Walks every (map size, removed key) pair for ascending inserts up to 40
-        // elements, which covers all of the shapes the deletion fix-up has to handle.
+        // Walks every (map size, removed key) pair for ascending inserts up to 40 elements.
+        // That is not every tree shape a red-black tree can take, but it does reach all four
+        // deletion cases (no child, one child, two children with the successor as the removed
+        // node's right child, and two children with a deeper successor) in both colours.
         assertTerminates("remove each key of every map size", timeout: 60) {
             for size in 1...40 {
                 for key in 1...size {
@@ -185,14 +188,18 @@ class TreeMapTests: XCTestCase {
                     XCTAssertEqual(map.keys, expected, context)
                     XCTAssertEqual(map.values, expected.map { $0 * 10 }, context)
                     XCTAssertEqual(map.count, expected.count, context)
+                    XCTAssertNil(map.firstRedBlackInvariantViolation(), context)
                 }
             }
         }
     }
 
     func testRandomizedInsertAndRemoveMatchesDictionary() {
-        // Interleaves inserts and removals and compares against a plain dictionary,
-        // so any ordering, count or return value drift shows up.
+        // Interleaves inserts and removals and compares against a plain dictionary, so any
+        // ordering, count or return value drift shows up. The red-black invariants are checked
+        // after every single mutation as well: a broken rebalance keeps handing back the right
+        // keys and counts while the tree quietly degrades toward a plain binary search tree,
+        // which no amount of checking the results would catch.
         assertTerminates("randomized insert/remove", timeout: 60) {
             var generator = SeededGenerator(seed: 0x5EED)
 
@@ -207,6 +214,11 @@ class TreeMapTests: XCTestCase {
                         reference[key] = key * 3
                     } else {
                         XCTAssertEqual(map.remove(key: key), reference.removeValue(forKey: key), "round \(round)")
+                    }
+
+                    if let violation = map.firstRedBlackInvariantViolation() {
+                        XCTFail("round \(round), key \(key): \(violation)")
+                        return
                     }
                 }
 

--- a/SideStore/Tests/UnitTests/datastructures/TreeMapTests.swift
+++ b/SideStore/Tests/UnitTests/datastructures/TreeMapTests.swift
@@ -7,6 +7,7 @@
 //
 
 
+import Foundation
 import XCTest
 
 class TreeMapTests: XCTestCase {
@@ -150,5 +151,109 @@ class TreeMapTests: XCTestCase {
         XCTAssertEqual(oldValue, "first")
         XCTAssertEqual(map["a"], "second")
         XCTAssertEqual(map.count, 1)
+    }
+
+    // MARK: - Deletion Regression Tests
+
+    func testRemoveRootWithBlackSuccessorTerminates() {
+        // Inserting 1...6 in ascending order leaves a root with two children whose
+        // in-order successor is black. Removing that root used to hand the deletion
+        // fix-up the wrong parent node, and the fix-up then looped forever.
+        assertTerminates("remove the root of a 6 element map") {
+            let map = TreeMap<Int, Int>()
+            for i in 1...6 { map[i] = i }
+
+            XCTAssertEqual(map.remove(key: 2), 2)
+            XCTAssertNil(map[2])
+            XCTAssertEqual(map.keys, [1, 3, 4, 5, 6])
+            XCTAssertEqual(map.count, 5)
+        }
+    }
+
+    func testEverySingleRemovalKeepsMapConsistent() {
+        // Walks every (map size, removed key) pair for ascending inserts up to 40
+        // elements, which covers all of the shapes the deletion fix-up has to handle.
+        assertTerminates("remove each key of every map size", timeout: 60) {
+            for size in 1...40 {
+                for key in 1...size {
+                    let map = TreeMap<Int, Int>()
+                    for i in 1...size { map[i] = i * 10 }
+
+                    let context = "size \(size), removed \(key)"
+                    let expected = (1...size).filter { $0 != key }
+                    XCTAssertEqual(map.remove(key: key), key * 10, context)
+                    XCTAssertEqual(map.keys, expected, context)
+                    XCTAssertEqual(map.values, expected.map { $0 * 10 }, context)
+                    XCTAssertEqual(map.count, expected.count, context)
+                }
+            }
+        }
+    }
+
+    func testRandomizedInsertAndRemoveMatchesDictionary() {
+        // Interleaves inserts and removals and compares against a plain dictionary,
+        // so any ordering, count or return value drift shows up.
+        assertTerminates("randomized insert/remove", timeout: 60) {
+            var generator = SeededGenerator(seed: 0x5EED)
+
+            for round in 1...50 {
+                let map = TreeMap<Int, Int>()
+                var reference: [Int: Int] = [:]
+
+                for _ in 0..<500 {
+                    let key = Int.random(in: 0..<150, using: &generator)
+                    if Bool.random(using: &generator) {
+                        map[key] = key * 3
+                        reference[key] = key * 3
+                    } else {
+                        XCTAssertEqual(map.remove(key: key), reference.removeValue(forKey: key), "round \(round)")
+                    }
+                }
+
+                let expectedKeys = reference.keys.sorted()
+                XCTAssertEqual(map.keys, expectedKeys, "round \(round)")
+                XCTAssertEqual(map.values, expectedKeys.map { reference[$0]! }, "round \(round)")
+                XCTAssertEqual(map.count, reference.count, "round \(round)")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Runs `work` on its own thread and reports a failure if it does not finish in time.
+    /// A broken deletion fix-up spins forever rather than returning a wrong answer, so the
+    /// test has to be able to give up on it instead of hanging the whole test run.
+    private func assertTerminates(_ label: String,
+                                  timeout: TimeInterval = 30,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line,
+                                  work: @escaping @Sendable () -> Void) {
+        let finished = DispatchSemaphore(value: 0)
+        Thread.detachNewThread {
+            work()
+            finished.signal()
+        }
+
+        if finished.wait(timeout: .now() + timeout) == .timedOut {
+            XCTFail("\(label) did not finish within \(Int(timeout))s, TreeMap is looping forever", file: file, line: line)
+        }
+    }
+}
+
+/// Seeded generator (splitmix64) so a failing randomized case is reproducible.
+private struct SeededGenerator: RandomNumberGenerator {
+
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state = state &+ 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
     }
 }

--- a/SideStore/Utils/datastructures/TreeMap.swift
+++ b/SideStore/Utils/datastructures/TreeMap.swift
@@ -399,4 +399,63 @@ public class TreeMap<Key: Comparable, Value>: Sequence {
     public func makeIterator() -> Iterator {
         return Iterator(root: root)
     }
+    
+    // MARK: - Invariant Checking (test hook)
+    
+    /// Walks the tree and returns a description of the first red-black invariant it finds
+    /// violated, or `nil` when the tree is well formed.
+    ///
+    /// Meant for tests. A broken rebalance keeps returning the right keys, values and counts
+    /// while quietly wrecking the structure, so checking the result of an operation is not
+    /// enough to notice it - the tree has to be inspected from the inside, which only code in
+    /// this file can do.
+    func firstRedBlackInvariantViolation() -> String? {
+        guard let root = root else {
+            return count == 0 ? nil : "empty tree reports a count of \(count)"
+        }
+        
+        if root.color != .black { return "root \(root.key) is red" }
+        if root.parent != nil { return "root \(root.key) still points at a parent" }
+        
+        var violation: String? = nil
+        var nodeCount = 0
+        
+        // Returns the number of black nodes on the paths from `node` down to its leaves,
+        // recording a violation if those paths disagree.
+        func blackHeight(of node: Node?, parent: Node?) -> Int {
+            guard let node = node else { return 1 }  // missing children count as black
+            
+            nodeCount += 1
+            
+            if node.parent !== parent {
+                violation = violation ?? "\(node.key) points at the wrong parent"
+            }
+            if node.color == .red, node.left?.color == .red || node.right?.color == .red {
+                violation = violation ?? "red node \(node.key) has a red child"
+            }
+            if let left = node.left, left.key >= node.key {
+                violation = violation ?? "left child \(left.key) of \(node.key) is out of order"
+            }
+            if let right = node.right, right.key <= node.key {
+                violation = violation ?? "right child \(right.key) of \(node.key) is out of order"
+            }
+            
+            let leftHeight = blackHeight(of: node.left, parent: node)
+            let rightHeight = blackHeight(of: node.right, parent: node)
+            
+            if leftHeight != rightHeight {
+                violation = violation ?? "\(node.key) has black heights \(leftHeight) and \(rightHeight)"
+            }
+            
+            return leftHeight + (node.color == .black ? 1 : 0)
+        }
+        
+        _ = blackHeight(of: root, parent: nil)
+        
+        if violation == nil, nodeCount != count {
+            violation = "tree holds \(nodeCount) nodes but reports a count of \(count)"
+        }
+        
+        return violation
+    }
 }

--- a/SideStore/Utils/datastructures/TreeMap.swift
+++ b/SideStore/Utils/datastructures/TreeMap.swift
@@ -274,9 +274,16 @@ public class TreeMap<Key: Comparable, Value>: Sequence {
             y = minimum(z.right!)
             let yOriginalColor = y.color
             x = y.right
+            // Parent that `x` sits under once `y` has been spliced out of its old spot
+            // and moved into z's place. It has to be captured here: `transplant(z, y)`
+            // below overwrites `y.parent` with z's parent, so reading it afterwards
+            // would point the fix-up at the wrong subtree.
+            let xParent: Node?
             if y.parent === z {
+                xParent = y
                 if x != nil { x!.parent = y }
             } else {
+                xParent = y.parent
                 transplant(y, y.right)
                 y.right = z.right
                 y.right?.parent = y
@@ -286,7 +293,7 @@ public class TreeMap<Key: Comparable, Value>: Sequence {
             y.left?.parent = y
             y.color = z.color
             if yOriginalColor == .black {
-                fixAfterDeletion(x, parent: y.parent)
+                fixAfterDeletion(x, parent: xParent)
             }
             return
         }
@@ -299,7 +306,10 @@ public class TreeMap<Key: Comparable, Value>: Sequence {
     private func fixAfterDeletion(_ x: Node?, parent: Node?) {
         var x = x
         var parent = parent
-        while (x == nil || x!.color == .black) && (x !== root) {
+        // For a well-formed tree `parent != nil` is implied by `x !== root`; keeping it in
+        // the condition makes the loop total, so a bad (x, parent) pair can never spin
+        // forever or force-unwrap a nil parent.
+        while (x == nil || x!.color == .black) && (x !== root) && (parent != nil) {
             if x === parent?.left {
                 var w = parent?.right
                 if w?.color == .red {
@@ -357,11 +367,6 @@ public class TreeMap<Key: Comparable, Value>: Sequence {
             }
         }
         x?.color = .black
-    }
-    
-    // Convenience overload if parent is not separately tracked.
-    private func fixAfterDeletion(_ x: Node?) {
-        fixAfterDeletion(x, parent: x?.parent)
     }
     
     // MARK: - Sequence Conformance (In-Order Traversal)


### PR DESCRIPTION
### Description of Changes

`TreeMap.remove(key:)` can spin forever. The red-black delete fix-up is started from the wrong node whenever the removed node has two children.

- `deleteNode(_:)` now captures the parent that `x` actually ends up under **before** `transplant(z, y)` overwrites `y.parent`, and passes that to `fixAfterDeletion(_:parent:)`.
- `fixAfterDeletion(_:parent:)` keeps `parent != nil` in the loop condition, so an inconsistent `(x, parent)` pair can no longer loop endlessly or force-unwrap a `nil` parent.
- Removed the unused `fixAfterDeletion(_:)` convenience overload; it recreates exactly this bug, because `x?.parent` is `nil` when `x` is `nil` (the common case) and there is no way to recover the parent from there.
- Added regression tests for the shapes that used to hang, plus `firstRedBlackInvariantViolation()` next to the implementation so those tests can check the tree's structure and not only its answers.

### Rationale behind Changes

In the two-children branch of `deleteNode(_:)` the fix-up was called as:

```swift
transplant(z, y)          // sets y.parent = z.parent
...
fixAfterDeletion(x, parent: y.parent)   // z's parent, not x's parent
```

`x` is `y.right`, so its parent after the splice is either `y` itself (when `y.parent === z`) or `y`'s *original* parent. By the time `y.parent` is read it has already been overwritten with `z`'s parent by `transplant(z, y)`, so the rebalance runs on an unrelated part of the tree. Two consequences:

* **Broken invariants.** Nodes are recoloured and rotated in the wrong subtree, so the tree comes out with red-red or black-height violations and loses its height guarantee.
* **Infinite loop.** When the removed node is the root, the wrongly passed parent is `nil`. `fixAfterDeletion` then does `x = parent` (`nil`), `parent = x?.parent` (`nil`) and re-tests `(x == nil) && (x !== root)`, which stays true forever.

Smallest repro, hangs on `develop`:

```swift
let map = TreeMap<Int, Int>()
for i in 1...6 { map[i] = i }
map.remove(key: 2)   // never returns
```

I measured the blast radius over every `(size, removed key)` pair for ascending inserts of `1...n`, `n = 1...40` (820 cases), using a copy of `TreeMap` with a red-black validator and a cap on the fix-up loop:

| | before | after |
|---|---|---|
| cases that never return | 35 | 0 |
| cases left with a red-red / black-height violation | 324 | 0 |
| cases returning wrong keys or counts | 0 | 0 |

So no data is lost - the map either hangs or silently degrades toward a plain BST. On top of that, 200 seeds x 400 randomized insert/remove ops keep every red-black invariant intact after the fix and stay within a `2*log2(n+1)` height bound, and the key/value/count results match a reference `Dictionary` exactly.

`TreeMap` has no call sites in the app today (`LinkedHashMap` next to it does), so nothing user-facing regresses right now - but it ships as a general purpose utility with its own test suite, and the next caller that deletes a root would freeze the thread it runs on.

### Suggested Testing Steps

The quickest check is the repro above: put those three lines anywhere that runs (a scratch target, or `swiftc TreeMap.swift main.swift` outside Xcode) and watch it return instead of pinning a core.

How I verified it, since I could not run the app's test bundle: I built `TreeMap.swift` standalone with `swiftc` and ran

* every `(map size, removed key)` pair for `n = 1...40` - the table above,
* 200 seeds x 400 randomized insert/remove ops against a reference `Dictionary`, checking the red-black invariants after every mutation,
* the three new test cases, exactly as they are written here,
* the existing `TreeMapTests` scenarios replayed by hand - they pass both before and after this change, because none of them builds a shape that spins.

The invariant check the harness used now lives in `TreeMap.swift` itself as `firstRedBlackInvariantViolation()` (internal, since `root` and `Node` are private, so no caller outside that file could walk the tree) and the tests assert on it. That matters because this bug is invisible to result based assertions: on the unfixed code, 324 of the 820 sweep cases come back structurally broken while `keys`, `values`, `count` and the returned value are all still correct.

Heads-up on the test file itself: `SideStore/Tests/UnitTests/**` is currently not built by anything - `AltStore.xcodeproj` has no unit test target (only `SideStore`, `AltWidgetExtension` and `SideBackup`), those files are listed under `membershipExceptions` for the `SideStore` target, and the scheme's test action points at `container:SideStore/Tests/SideStoreTests.xctestplan`, which isn't in the repo. So the new cases are written to run but won't actually execute until the test target is wired back up. I kept them next to the existing `TreeMapTests` so they come along when it is; happy to split them out or drop them if you'd rather land only the fix.

The new tests run their work on a detached thread with a semaphore watchdog, so if this ever regresses the test *fails* with a clear message rather than hanging the whole test run.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. I used Claude Code while working on this: reading through the red-black implementation to spot the mismatch against the CLRS delete procedure, building the Linux harness (a standalone `swiftc` build of `TreeMap.swift` plus an invariant validator) that produced the numbers above, and drafting the tests. I reviewed the reasoning, the patch and every number in the table myself against the harness output before opening this PR.
