### PR TITLE
fix: keep appIdName ASCII so non-latin app names install again (#1489)

### DIFF
--- a/SideStore/Core/Operations/PipelineOperations/FetchProvisioningProfilesOperation.swift
+++ b/SideStore/Core/Operations/PipelineOperations/FetchProvisioningProfilesOperation.swift
@@ -210,8 +210,10 @@ private extension FetchProvisioningProfilesOperation{
             
             let sortedExpirationDates = appIDs.compactMap { $0.expirationDate }.sorted(by: { $0 < $1 })
             
-            let sanitized = name.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }
-            let appIDName = sanitized.isEmpty ? bundleIdentifier : sanitized
+            // Falls back to the bundle identifier when the name has nothing usable left in it
+            // (e.g. "哔哩哔哩"), sanitized the same way so its periods cannot be rejected either.
+            let appIDName = [name.sanitizedForAppIDName, bundleIdentifier.sanitizedForAppIDName]
+                .first { !$0.isEmpty } ?? "SideStore App"
             
             self.debugLog("[FetchProvisioningProfiles] Calling DeveloperPortalProxy.shared.addAppID with name '\(appIDName)' and identifier '\(bundleIdentifier)'...")
             let appID = try await DeveloperPortalProxy.shared.addAppID(name: appIDName, bundleIdentifier: bundleIdentifier, team: team)
@@ -426,5 +428,27 @@ private extension FetchProvisioningProfilesOperation{
         }
 
         return groupIdentifier + "." + team.identifier
+    }
+}
+
+private extension String {
+
+    /// Apple's developer portal only accepts ASCII letters, digits and spaces for an App ID name
+    /// and rejects everything else with
+    /// `An invalid value '...' was provided for the parameter 'appIdName'`.
+    ///
+    /// `isLetter` and `isNumber` are Unicode aware, so a name written in Chinese, Japanese,
+    /// Cyrillic and so on satisfies them and reaches the portal untouched. Diacritics are folded
+    /// first so that "Café" keeps its letters ("Cafe"), anything the portal does not accept
+    /// becomes a space, and runs of spaces are collapsed.
+    var sanitizedForAppIDName: String {
+        let folded = self.folding(options: [.diacriticInsensitive], locale: nil)
+
+        let allowed = folded.map { character -> Character in
+            guard character.isASCII, character.isLetter || character.isNumber else { return " " }
+            return character
+        }
+
+        return String(allowed).split(separator: " ").joined(separator: " ")
     }
 }


### PR DESCRIPTION
Fixes #1489

### Description of Changes

App names that aren't ASCII are sent to Apple's developer portal unchanged and come back rejected, so apps like 哔哩哔哩 can't be installed at all - the reporter had to rename the app inside the IPA to get past it.

`registerAppID` now sanitizes the name into what the portal actually accepts:

- ASCII letters, digits and single spaces only, everything else collapsed into a space,
- diacritics folded first, so `Café Noir` keeps its letters (`Cafe Noir`) instead of ending up as `Caf Noir`,
- the bundle identifier fallback (used when a name has nothing usable left, e.g. `哔哩哔哩`) goes through the same rule, so it can't reintroduce characters the portal rejects.

### Rationale behind Changes

`8dd1c30` ("fetch profiles was not properly sanitizing name") replaced

```swift
//App ID name must be ascii. If the name is not ascii, using bundleID instead
if !name.allSatisfy({ $0.isASCII }) { appIDName = bundleIdentifier } else { appIDName = name }
```

with

```swift
let sanitized = name.filter { $0.isLetter || $0.isNumber || $0.isWhitespace }
```

That fixed the `Apollo (legacy)` case, but `Character.isLetter` and `Character.isNumber` are Unicode aware: `"哔".isLetter` is `true`, so CJK, Cyrillic, Greek, accented latin and so on all pass the filter untouched and the ASCII guarantee that the old branch provided was lost. #1489 was filed against `0.6.4-20260905.1381`, four days after that commit, with exactly the portal error the old comment described:

> Bundle identifier unavailable: An invalid value '哔哩哔哩' was provided for the parameter 'appIdName'.

Two smaller problems came along with it:

- `$0.isWhitespace` also passes tabs, newlines and U+00A0, and doesn't collapse runs, so `"Delta  Emulator\t"` reached the portal as-is.
- the fallback was the raw bundle identifier, i.e. a string full of periods, which is not something this field accepts either - so a name with no usable characters failed in a second way.

Running both versions over a set of real app names (pure `swiftc` build of the two sanitizers, `Character` classification only):

| name | current | this PR |
|---|---|---|
| `哔哩哔哩` | `哔哩哔哩` rejected | `tv danmaku bilianime TEAMID` |
| `微信WeChat` | `微信WeChat` rejected | `WeChat` |
| `Bilibili 哔哩哔哩` | `Bilibili 哔哩哔哩` rejected | `Bilibili` |
| `ЯндексMusic` | `ЯндексMusic` rejected | `Music` |
| `Café Noir` | `Café Noir` rejected | `Cafe Noir` |
| `Delta  Emulator\t` | `Delta  Emulator\t` rejected | `Delta Emulator` |
| `★` | `com.star.app.TEAMID` (periods) | `com star app TEAMID` |
| `Apollo (legacy)` | `Apollo legacy` | `Apollo legacy` |
| `Apollo Apollo (legacy) Widget` | `Apollo Apollo legacy Widget` | `Apollo Apollo legacy Widget` |
| `YouTube` / `2048` | unchanged | unchanged |

10 of the 15 names I tried currently produce a value the portal won't take; none do after the change, and the `(legacy)` case that `8dd1c30` fixed keeps working. (The non-ASCII rejections are the ones #1489 demonstrates; the periods in the fallback are the documented "no special characters" rule for this field, which is why the fallback is sanitized too rather than left as-is.)

Scope note: `DeveloperServicesViewModel.createAppID` is left alone on purpose - there the name is typed by the user in developer settings, so surfacing the portal's error is better than silently rewriting what they typed. This only touches the automatic path, where the name comes from the IPA and the user's only workaround is repacking it.

### Suggested Testing Steps

1. Install any app whose display name isn't ASCII (哔哩哔哩, WeChat, a Cyrillic-named app) with a fresh bundle ID, so a new App ID has to be registered. It used to fail with `An invalid value '...' was provided for the parameter 'appIdName'`; it now registers.
2. Check the App IDs list in the developer portal (or Settings -> Advanced -> Developer Services): the new entry is named after the ASCII part of the app name, or after the bundle identifier when there is none.
3. Re-install `Apollo (legacy)` or any app with punctuation/extensions to confirm the earlier `8dd1c30` fix still holds.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. I used Claude Code to help trace the regression back to `8dd1c30`, to build the standalone `swiftc` harness that produced the comparison table above, and to draft the patch and this description. I checked the git history, the reasoning and each row of the table against the harness output myself before opening the PR.
