### PR TITLE
fix: anchor share sheets so exporting from settings doesn't crash on iPad (#1473)

### DIFF
--- a/SideStore/Extensions/UIViewController+ShareSheet.swift
+++ b/SideStore/Extensions/UIViewController+ShareSheet.swift
@@ -1,0 +1,41 @@
+//
+//  UIViewController+ShareSheet.swift
+//  SideStore
+//
+//  Copyright © 2026 SideStore. All rights reserved.
+//
+
+#if !os(tvOS)
+
+import UIKit
+
+extension UIViewController {
+    
+    /// Presents a share sheet for `items`, anchored to this view controller.
+    ///
+    /// Wherever the trait environment calls for it - an iPad, or a regular width window on any
+    /// device - UIKit presents `UIActivityViewController` as a popover, and a popover without an
+    /// anchor throws before it can appear:
+    ///
+    /// > UIPopoverPresentationController (...) should have a non-nil sourceView or barButtonItem
+    /// > set before the presentation occurs.
+    ///
+    /// These sheets are opened from SwiftUI rows that have no UIKit view to point at, so the
+    /// popover is centred on the presenting view controller with no arrow.
+    func presentShareSheet(for items: [Any],
+                           applicationActivities: [UIActivity]? = nil,
+                           animated: Bool = true) {
+        let activityViewController = UIActivityViewController(activityItems: items,
+                                                              applicationActivities: applicationActivities)
+        
+        if let popover = activityViewController.popoverPresentationController {
+            popover.sourceView = self.view
+            popover.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+        
+        self.present(activityViewController, animated: animated)
+    }
+}
+
+#endif

--- a/SideStore/Views/Settings/Advanced/Anisette/AnisetteDataView.swift
+++ b/SideStore/Views/Settings/Advanced/Anisette/AnisetteDataView.swift
@@ -624,13 +624,7 @@ struct AnisetteDataView: View {
                                 if let url = await viewModel.exportJSON() {
                                     #if !os(tvOS)
                                     guard let topVC = UIApplication.shared.topViewController() else { return }
-                                    let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-                                    if let popover = activityVC.popoverPresentationController {
-                                        popover.sourceView = topVC.view
-                                        popover.sourceRect = CGRect(x: topVC.view.bounds.midX, y: topVC.view.bounds.midY, width: 0, height: 0)
-                                        popover.permittedArrowDirections = []
-                                    }
-                                    topVC.present(activityVC, animated: true)
+                                    topVC.presentShareSheet(for: [url])
                                     #else
                                     if let topVC = UIApplication.shared.topViewController() {
                                         TVWebFileTransferManager.shared.startExport(

--- a/SideStore/Views/Settings/Advanced/BackupRestore/BackupAndRestoreView.swift
+++ b/SideStore/Views/Settings/Advanced/BackupRestore/BackupAndRestoreView.swift
@@ -207,8 +207,7 @@ struct BackupAndRestoreView: View {
                 try encryptedData.write(to: fileURL)
                 
                 #if !os(tvOS)
-                let activityVC = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)
-                top.present(activityVC, animated: true)
+                top.presentShareSheet(for: [fileURL])
                 #else
                 TVWebFileTransferManager.shared.startExport(fileURL: fileURL, title: "Export Account", presentingVC: top)
                 #endif

--- a/SideStore/Views/Settings/Advanced/Certificates/CertificateExporter.swift
+++ b/SideStore/Views/Settings/Advanced/Certificates/CertificateExporter.swift
@@ -66,13 +66,7 @@ enum CertificateExporter {
         }
         guard let rootVC = UIApplication.shared.topViewController() else { return }
         #if !os(tvOS)
-        let activityVC = UIActivityViewController(activityItems: [tempURL], applicationActivities: nil)
-        if let popover = activityVC.popoverPresentationController {
-            popover.sourceView = rootVC.view
-            popover.sourceRect = CGRect(x: rootVC.view.bounds.midX, y: rootVC.view.bounds.midY, width: 0, height: 0)
-            popover.permittedArrowDirections = []
-        }
-        rootVC.present(activityVC, animated: true)
+        rootVC.presentShareSheet(for: [tempURL])
         #else
         TVWebFileTransferManager.shared.startExport(fileURL: tempURL, title: "Export Certificate / Key", presentingVC: rootVC)
         #endif

--- a/SideStore/Views/Settings/Advanced/DeveloperServices/Profiles/ProfilePortalDetailView.swift
+++ b/SideStore/Views/Settings/Advanced/DeveloperServices/Profiles/ProfilePortalDetailView.swift
@@ -247,11 +247,7 @@ struct ProfilePortalDetailView: View {
                         do {
                             try downloaded.data.write(to: tempURL)
                             #if !os(tvOS)
-                            let activityVC = UIActivityViewController(activityItems: [tempURL], applicationActivities: nil)
-                            if let popover = activityVC.popoverPresentationController {
-                                popover.sourceView = presentingViewController?.view
-                            }
-                            presentingViewController?.present(activityVC, animated: true)
+                            presentingViewController?.presentShareSheet(for: [tempURL])
                             #endif
                         } catch {
                             debugLog("[ProfilePortalDetailView] Failed to write profile to temp: \(error)")

--- a/SideStore/Views/Settings/Advanced/SideSign/SideSignConfigurationView.swift
+++ b/SideStore/Views/Settings/Advanced/SideSign/SideSignConfigurationView.swift
@@ -400,13 +400,7 @@ struct SideSignConfigurationView: View {
                                 if let url = await viewModel.exportJSON() {
                                     #if !os(tvOS)
                                     guard let topVC = UIApplication.shared.topViewController() else { return }
-                                    let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-                                    if let popover = activityVC.popoverPresentationController {
-                                        popover.sourceView = topVC.view
-                                        popover.sourceRect = CGRect(x: topVC.view.bounds.midX, y: topVC.view.bounds.midY, width: 0, height: 0)
-                                        popover.permittedArrowDirections = []
-                                    }
-                                    topVC.present(activityVC, animated: true)
+                                    topVC.presentShareSheet(for: [url])
                                     #else
                                     if let topVC = UIApplication.shared.topViewController() {
                                         TVWebFileTransferManager.shared.startExport(

--- a/SideStore/Views/Settings/Advanced/UserCustomizations/UserCustomizationsView.swift
+++ b/SideStore/Views/Settings/Advanced/UserCustomizations/UserCustomizationsView.swift
@@ -521,8 +521,7 @@ struct UserCustomizationsView: View {
             return
         }
         #if !os(tvOS)
-        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
-        top.present(activityVC, animated: true)
+        top.presentShareSheet(for: [url])
         #else
         TVWebFileTransferManager.shared.startExport(fileURL: url, title: "Export SideStore.conf", presentingVC: top)
         #endif


### PR DESCRIPTION
Fixes #1473

### Description of Changes

Exporting from Settings crashes on iPad. The reporter's screenshot in #1473 shows the exception:

> `UIPopoverPresentationController (<UIPopoverPresentationController: 0x13b305f80>) should have a non-nil sourceView or barButtonItem set before the presentation occurs.`

Adds `UIViewController.presentShareSheet(for:)`, which anchors the popover before presenting, and routes every `UIActivityViewController` presentation through it:

| call site | before |
|---|---|
| `UserCustomizationsView` - Export WireGuard Config | no anchor -> **crash on iPad** (#1473) |
| `BackupAndRestoreView` - Export Account | no anchor -> **crash on iPad** |
| `ProfilePortalDetailView` - export .mobileprovision | `sourceView` only, no `sourceRect` -> popover in the top left corner |
| `CertificateExporter` | correct, six lines, copy-pasted |
| `AnisetteDataView` | correct, the same six lines |
| `SideSignConfigurationView` | correct, the same six lines |

Net result is 30 lines of duplication replaced by 6 calls plus one helper.

### Rationale behind Changes

Wherever the trait environment calls for it - any iPad, and regular width windows generally - UIKit gives `UIActivityViewController` a `UIPopoverPresentationController`, and a popover has to know what it points at before `present` is called. Three of the six exporters in Settings already do this, with the identical snippet pasted into each:

```swift
if let popover = activityVC.popoverPresentationController {
    popover.sourceView = topVC.view
    popover.sourceRect = CGRect(x: topVC.view.bounds.midX, y: topVC.view.bounds.midY, width: 0, height: 0)
    popover.permittedArrowDirections = []
}
```

The two that don't are the two that crash, which is what a copy-pasted precondition tends to do eventually - so the fix puts it in one place rather than pasting it a fourth and fifth time. These sheets are opened from SwiftUI rows with no UIKit view to point at, so the helper keeps what the existing three chose: centred on the presenting view controller, no arrow.

Scope notes:

- The share sheets that go through `UIViewControllerRepresentable` + `.sheet` (`CacheManagementView`, `BundleResourceBrowserView`) are presented by SwiftUI, not by `present`, so they are not affected and are left alone.
- `#if !os(tvOS)` on the helper, matching how each call site already guards the iOS-only branch.
- iPhone behaviour is unchanged: the sheet isn't a popover there, `popoverPresentationController` is nil, and the anchoring block is skipped.

### Suggested Testing Steps

On an iPad (or an iPad simulator), on `develop` first to see the crash, then with this branch:

1. Settings -> Advanced -> User Customizations -> **Export WireGuard Config** - this is #1473; it now opens the share sheet centred on the screen instead of throwing.
2. Settings -> Advanced -> Backup & Restore -> **Export Account** - same crash, same fix.
3. Export a certificate / key, the anisette JSON, the SideSign JSON and a provisioning profile - all still open, with the profile one now centred like the rest.
4. On iPhone, the same five exports should look exactly as before.

I could not run the app itself (no Mac here), so the iPad behaviour above rests on the crash in #1473 and on the pattern the three working exporters already established; what I did verify is that the six sites are the only ones calling `present` with an activity controller, that the two crashing ones had no anchoring at all, and that every touched file still parses.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. I used Claude Code to read the crash screenshot attached to #1473, to find every `UIActivityViewController` presentation in the project and sort out which ones were anchored, and to draft the helper and this description. I reviewed the diff and each claim in the table myself before opening the PR.
