### PR TITLE
fix: anchor the backup and restore action sheets so they don't crash on iPad (#1524)

### DIFF
--- a/AltStore/My Apps/MyAppsViewController.swift
+++ b/AltStore/My Apps/MyAppsViewController.swift
@@ -1382,6 +1382,11 @@ private extension MyAppsViewController
                 }
             }))
             
+            if let popoverController = alertController.popoverPresentationController {
+                popoverController.sourceView = self.view
+                popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            }
+            
             self.present(alertController, animated: true, completion: nil)
         }
     }
@@ -1459,6 +1464,11 @@ private extension MyAppsViewController
                     self.collectionView.reloadSections([Section.activeApps.rawValue])
                 }
             }))
+            
+            if let popoverController = alertController.popoverPresentationController {
+                popoverController.sourceView = self.view
+                popoverController.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            }
             
             self.present(alertController, animated: true, completion: nil)
         }


### PR DESCRIPTION
Fixes #1524

### Description of Changes

`MyAppsViewController.backup(_:)` and `restore(_:)` present a `.actionSheet` without setting an anchor, so on iPad both crash before the sheet appears:

> UIPopoverPresentationController (...) should have a non-nil sourceView or barButtonItem set before the presentation occurs.

Adds the anchoring block to both, copied from `clearCache()` a few hundred lines away in `SettingsViewController`:

| action | sheet | presented | reached from |
|---|---|---|---|
| `backup(_:)` "Start Backup?" | `:1354` | `:1385` | **Create Backup** (`:1918`) |
| `restore(_:)` "Are you sure you want to restore this backup?" | `:1437` | `:1463` | **Restore Backup** (`:1930`), and `restorePreviousBackup(for:)` |

Both actions sit in `backupSubmenuActions` -> the "Backup" submenu (`:2019`) of the cell context menu (`:2156`).

### Rationale behind Changes

Same class as #1473: UIKit turns a `.actionSheet` into a popover wherever the trait environment calls for one, and a popover has to know what it points at before `present` is called. After 9a50d975 the share sheets are all `.sheet`-hosted, but these two alerts were never part of that, and they are the only two action sheets in the app with no anchor - `clearCache()` and `makeExplorerVC(url:)` set `sourceView` + `sourceRect`, `clearLoggedErrors(_:)` sets `barButtonItem`.

I kept the block byte-identical to `clearCache()` rather than inventing a variant, so the sheet is centred on the view controller. Two notes on that choice, both easy to change if you'd rather:

- anchoring to the app's cell would look nicer than centring, but it means resolving the `InstalledApp` back to an index path, and the existing convention here is the centred one;
- `clearCache()` doesn't set `permittedArrowDirections = []`, so a centred popover still draws an arrow. I matched it for consistency; adding `[]` in all three places would be a tidier follow-up.

iPhone is unaffected - `.actionSheet` isn't a popover there, `popoverPresentationController` is nil, and the block is skipped.

### Suggested Testing Steps

On an iPad (or iPad simulator), on `develop` first to see the crash, then with this branch:

1. My Apps -> long press an installed app -> **Backup** -> **Create Backup**. The "Start Backup?" sheet should now appear centred instead of throwing.
2. Same menu -> **Restore Backup** (on an app that has a backup), same result.
3. On iPhone, both sheets should look exactly as before.

I could not run the app to confirm the iPad behaviour (no Mac here), so this rests on the exception in #1473 and on the three action sheets in the project that already do this. What I did check is that these two are the only unanchored `.actionSheet` presentations left, that both are reachable from the context menu rather than dead code, and that the file still parses.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. I used Claude Code to sweep the project for `.actionSheet` presentations and sort out which ones were anchored, to trace both call sites back to the context menu, and to draft this description. The change itself is the existing `clearCache()` block, and I reviewed the diff and every line reference in the table before opening the PR.
