### PR TITLE
fix: scan hex colours as 64-bit so 8 digit values survive (#1527)

### DIFF
--- a/Shared/Extensions/UIColor+Hex.swift
+++ b/Shared/Extensions/UIColor+Hex.swift
@@ -25,9 +25,10 @@ public extension UIColor
     convenience init?(hexString: String)
     {
         let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        guard let int32 = Scanner(string: hex).scanInt32(representation: .hexadecimal), case let int = UInt32(int32) else { return nil }
+        // Scanned as 64-bit: an 8 digit value can reach 0xFFFFFFFF, which does not fit in an Int32.
+        guard let int = Scanner(string: hex).scanUInt64(representation: .hexadecimal) else { return nil }
         
-        let a, r, g, b: UInt32
+        let a, r, g, b: UInt64
         switch hex.count {
         case 3: // RGB (12-bit)
             (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)


### PR DESCRIPTION
Fixes #1527

### Description of Changes

`UIColor(hexString:)` scanned into an `Int32` and then converted to `UInt32`:

```swift
guard let int32 = Scanner(string: hex).scanInt32(representation: .hexadecimal), case let int = UInt32(int32) else { return nil }
```

`Int32.max` is `0x7FFFFFFF`, so the `case 8: // ARGB (32-bit)` branch below it could never see a colour whose alpha byte is `>= 0x80`. This scans into a `UInt64` instead, which covers the full 32-bit range, and drops the conversion that would have trapped if the scan ever returned a negative value rather than clamping.

3 lines, no behaviour change anywhere else: the switch is still driven by `hex.count`, so 3, 6 and 8 digits decode exactly as before and every other length still returns `nil`.

### Rationale behind Changes

Same decode, run on the values that currently can't get through:

| hex | fits in Int32 | today | with this change |
|---|---|---|---|
| `336699FF` | yes | a=51 r=102 g=153 b=255 | unchanged |
| `FF5733FF` | **no** | a=127 r=255 g=255 b=255 | a=255 r=87 g=51 b=255 |
| `80000000` | **no** | a=127 r=255 g=255 b=255 | a=128 r=0 g=0 b=0 |
| `112233` | yes | a=255 r=17 g=34 b=51 | unchanged |

Every 8-digit colour at or above `0x80000000` currently lands on the same translucent white, because that's what `Int32.max` decodes to. The input comes from source JSON - `tintColor` goes through this initializer in `AltStore/Core/Model/Source.swift:162`, `AltStore/Core/Model/StoreApp.swift:320` and `AltStore/Core/Model/NewsItem.swift:68`, and in `AltWidget/Model/AppSnapshot.swift:33` - so a source author writing an 8-digit tint gets a wrong colour with no error.

`UIColor(hex:)` in `ThemeManager.swift:66` already scans into a `UInt64` for exactly this reason; this brings the shared initializer in line with it. `scanUInt64(representation:)` is iOS 13+, and the project targets 15.0.

I left the other difference between the two parsers alone: they disagree on 8-digit byte order (this one reads ARGB, `UIColor(hex:)` reads RGBA). Worth settling at some point, but changing it would move colours for anyone already relying on either.

### Suggested Testing Steps

1. A source whose `tintColor` is `"FF5733FF"` should now render in that colour instead of a washed-out white.
2. Existing 6-digit tints (the common case) should look identical - the values below `0x80000000` never went through the clamp.
3. 3-digit shorthand and invalid strings behave as before.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. I used Claude Code to spot the Int32 scan while sweeping the shared extensions, to check the call sites the initializer is reached from, and to run the decode expressions in isolation to produce the table above. The change itself is three lines and I reviewed it, along with every line reference here, before opening the PR.
