### PR TITLE
fix: keep the previous build version so update notifications don't repeat (#1529)

### DIFF
--- a/AltStore/AppDelegate.swift
+++ b/AltStore/AppDelegate.swift
@@ -518,7 +518,7 @@ private extension AppDelegate
                         guard let previousVersion = previousUpdate[#keyPath(InstalledApp.storeApp.latestSupportedVersion.version)] else { continue }
                         
                         // previousUpdate might not contain buildVersion, but if it does then map empty string to nil to match AppVersion.
-                        let previousBuildVersion = previousUpdate[#keyPath(InstalledApp.storeApp.latestSupportedVersion._buildVersion)].map { $0.isEmpty ? nil : "" }
+                        let previousBuildVersion = previousUpdate[#keyPath(InstalledApp.storeApp.latestSupportedVersion._buildVersion)].flatMap { $0.isEmpty ? nil : $0 }
                         
                         // Only show notification if previous latestSupportedVersion does not _exactly_ match current latestSupportedVersion.
                         guard previousVersion != latestSupportedVersion.version || previousBuildVersion != latestSupportedVersion.buildVersion  else { continue }


### PR DESCRIPTION
Fixes #1529

### Description of Changes

One line in `AppDelegate.swift:521`:

```diff
-let previousBuildVersion = previousUpdate[#keyPath(...._buildVersion)].map { $0.isEmpty ? nil : "" }
+let previousBuildVersion = previousUpdate[#keyPath(...._buildVersion)].flatMap { $0.isEmpty ? nil : $0 }
```

The comment right above it already describes the intended behaviour ("map empty string to nil to match AppVersion"); the closure was mapping every non-empty string to `""` instead, so the previously seen build version was never actually compared.

### Rationale behind Changes

The guard below it exists to post "New Update Available" only once per version:

```swift
guard previousVersion != latestSupportedVersion.version || previousBuildVersion != latestSupportedVersion.buildVersion else { continue }
```

With the old closure a previously seen build version of `163` arrives at that comparison as `""`, never equals the current `163`, and the notification is re-posted on every update check. `.map` also nests the optional - `previousUpdate[...]` is `String?` and the closure returns `String?`, giving `String??` against a `String?` right-hand side - so the "neither side has a build version" case compares unequal as well.

I compiled the expression standalone with the same types and ran every case:

| previous -> current | as written | with `$0` | this PR (`flatMap` + `$0`) | should be |
|---|---|---|---|---|
| `163` -> `163` (nothing changed) | **notify** | suppress | suppress | suppress |
| `163` -> `164` | notify | notify | notify | notify |
| `""` -> none | suppress | suppress | suppress | suppress |
| `""` -> `163` | notify | notify | notify | notify |
| none -> none | **notify** | **notify** | suppress | suppress |
| none -> `163` | notify | notify | notify | notify |
| `163` -> none | notify | notify | notify | notify |

`flatMap` is what fixes both rows: it keeps the value and collapses the result back to `String?`, so the comparison is `String?` against `String?`.

Scope notes:

- Apps whose source has no `buildVersion` are unaffected - `_buildVersion` is a non-optional attribute storing `""`, which maps to nil on both sides either way. The apps that notify repeatedly today are the ones that do carry it, e.g. `Delta 2.0.4 (163)` and `Clip 1.2 (15)` in the official AltStore source.
- The same expression is in upstream `rileytestut/AltStore` on both `main` and `develop`, so this isn't a SideStore regression - but the fix stands on its own here.
- Nothing else in the file touches `previousBuildVersion`; the surrounding guard is unchanged.

### Suggested Testing Steps

1. Add `https://apps.altstore.io` as a source and have an outdated Delta installed so its update sits pending.
2. Let SideStore run an update check more than once (relaunch, or wait for a background refresh) without taking the update.
3. Before: "Delta 2.0.4 (163) is now available for download." arrives again each time. After: it arrives once, and again only when the source actually publishes a different version or build.
4. An app without a `buildVersion` (SideStore's own source, for instance) should behave exactly as before.

I don't have a Mac to run the app, so the behaviour above is from the standalone run of the expression plus the code path around it, not from a device.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. I used Claude Code to trace the notification path, to build the standalone harness that produced the table, and to check the real source data for `buildVersion` and the upstream AltStore code. The change itself is one word plus one token, and I reviewed it and the table before opening this.
