### PR TITLE
Fix misleading certificate recovery guidance

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,6 +63,9 @@ jobs:
             ~/Library/Caches/org.swift.swiftpm
           key: xcode-build-cache-${{ github.ref_name }}-
 
+      - name: Test certificate diagnostics
+        run: xcodebuild test -project AltStore.xcodeproj -scheme CertificateDiagnosticsTests -destination 'platform=macOS'
+
       - name: Build
         env:
           BUILD_LOG_ZIP_PASSWORD: ${{ secrets.BUILD_LOG_ZIP_PASSWORD }}

--- a/AltStore.xcodeproj/project.pbxproj
+++ b/AltStore.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		BF58047B246A28F7008AE704 /* SideBackup.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideBackup.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF989167250AABF3002ACF50 /* AltWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = AltWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD2476A2284B9A500981D42 /* SideStore.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideStore.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C3D1A6000000000000000001 /* CertificateDiagnosticsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CertificateDiagnosticsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -197,6 +198,7 @@
 			membershipExceptions = (
 				Tests/UITests/UITests.swift,
 				Tests/UITests/UITestsLaunchTests.swift,
+				Tests/UnitTests/certificates/CertificateDiagnosticsTests.swift,
 				Tests/UnitTests/datastructures/DataStructuresTests.swift,
 				Tests/UnitTests/datastructures/LinkedHashMapTests.swift,
 				Tests/UnitTests/datastructures/TreeMapTests.swift,
@@ -215,15 +217,32 @@
 			);
 			target = BF989166250AABF3002ACF50 /* AltWidgetExtension */;
 		};
+		C3D1A6000000000000000002 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Core/Certificates/CertificateStatus.swift,
+				Core/Operations/Errors/CertificateValidationContext.swift,
+				Core/Operations/Errors/OperationError.swift,
+				Tests/UnitTests/certificates/CertificateDiagnosticsTests.swift,
+			);
+			target = C3D1A6000000000000000004 /* CertificateDiagnosticsTests */;
+		};
+		C3D1A6000000000000000003 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Errors/ALTWrappedError.swift,
+			);
+			target = C3D1A6000000000000000004 /* CertificateDiagnosticsTests */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		A8EEC3482F4B0D8600F2436D /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8EEC36B2F4B0D8700F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, A82BE360304AAF490055C3DE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
+		A8EEC3482F4B0D8600F2436D /* Shared */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C3D1A6000000000000000003 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, A8EEC36B2F4B0D8700F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, A82BE360304AAF490055C3DE /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Shared; sourceTree = "<group>"; };
 		A8EEC3B92F4B0EFC00F2436D /* AltWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8EEC3CA2F4B0EFC00F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = AltWidget; sourceTree = "<group>"; };
 		A8EEC3D92F4B0FC800F2436D /* SideBackup */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8EEC3E22F4B0FC800F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SideBackup; sourceTree = "<group>"; };
 		A8EEC71D2F4B10D900F2436D /* xcconfigs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = xcconfigs; sourceTree = "<group>"; };
 		A8EEC8412F4B146A00F2436D /* AltStore */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8EEC8CB2F4B146B00F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, A8EEC8CD2F4B146B00F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = AltStore; sourceTree = "<group>"; };
-		A8EECF2A2F4B195000F2436D /* SideStore */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A8EECF492F4B195000F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, A8EECF4A2F4B195000F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SideStore; sourceTree = "<group>"; };
+		A8EECF2A2F4B195000F2436D /* SideStore */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C3D1A6000000000000000002 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, A8EECF492F4B195000F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, A8EECF4A2F4B195000F2436D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SideStore; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -255,6 +274,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C3D1A6000000000000000006 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -282,6 +308,7 @@
 		BFD2476B2284B9A500981D42 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				C3D1A6000000000000000001 /* CertificateDiagnosticsTests.xctest */,
 				BFD2476A2284B9A500981D42 /* SideStore.app */,
 				BF58047B246A28F7008AE704 /* SideBackup.app */,
 				BF989167250AABF3002ACF50 /* AltWidgetExtension.appex */,
@@ -369,6 +396,23 @@
 			productReference = BFD2476A2284B9A500981D42 /* SideStore.app */;
 			productType = "com.apple.product-type.application";
 		};
+		C3D1A6000000000000000004 /* CertificateDiagnosticsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C3D1A6000000000000000008 /* Build configuration list for PBXNativeTarget "CertificateDiagnosticsTests" */;
+			buildPhases = (
+				C3D1A6000000000000000005 /* Sources */,
+				C3D1A6000000000000000006 /* Frameworks */,
+				C3D1A6000000000000000007 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CertificateDiagnosticsTests;
+			productName = CertificateDiagnosticsTests;
+			productReference = C3D1A6000000000000000001 /* CertificateDiagnosticsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -423,6 +467,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				C3D1A6000000000000000004 /* CertificateDiagnosticsTests */,
 				BFD247692284B9A500981D42 /* SideStore */,
 				BF58047A246A28F7008AE704 /* SideBackup */,
 				BF989166250AABF3002ACF50 /* AltWidgetExtension */,
@@ -450,6 +495,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				A84596F62F7DC4C90000B8CD /* SideStore.conf in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C3D1A6000000000000000007 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -493,6 +545,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BFD247662284B9A500981D42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C3D1A6000000000000000005 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -895,6 +954,38 @@
 			};
 			name = Release;
 		};
+		C3D1A6000000000000000009 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_IDENTITY = "-";
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.SideStore.CertificateDiagnosticsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		C3D1A600000000000000000A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_IDENTITY = "-";
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.SideStore.CertificateDiagnosticsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -930,6 +1021,15 @@
 			buildConfigurations = (
 				BFD2477F2284B9A700981D42 /* Debug */,
 				BFD247802284B9A700981D42 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C3D1A6000000000000000008 /* Build configuration list for PBXNativeTarget "CertificateDiagnosticsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C3D1A6000000000000000009 /* Debug */,
+				C3D1A600000000000000000A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/AltStore.xcodeproj/xcshareddata/xcschemes/CertificateDiagnosticsTests.xcscheme
+++ b/AltStore.xcodeproj/xcshareddata/xcschemes/CertificateDiagnosticsTests.xcscheme
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C3D1A6000000000000000004"
+               BuildableName = "CertificateDiagnosticsTests.xctest"
+               BlueprintName = "CertificateDiagnosticsTests"
+               ReferencedContainer = "container:AltStore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C3D1A6000000000000000004"
+               BuildableName = "CertificateDiagnosticsTests.xctest"
+               BlueprintName = "CertificateDiagnosticsTests"
+               ReferencedContainer = "container:AltStore.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <AnalyzeAction buildConfiguration = "Debug">
+   </AnalyzeAction>
+</Scheme>

--- a/AltStore/Authentication/ResignAltStoreViewController.swift
+++ b/AltStore/Authentication/ResignAltStoreViewController.swift
@@ -152,10 +152,14 @@ private extension ResignAltStoreViewController
                             return
                         }
                         
-                        let alertController = UIAlertController(title: NSLocalizedString("Failed to Resign SideStore", comment: ""), message: error.localizedFailureReason ?? error.localizedDescription, preferredStyle: .alert)
-                        alertController.addAction(UIAlertAction(title: NSLocalizedString("Try Again", comment: ""), style: .default, handler: { (action) in
-                            refresh()
-                        }))
+                        let message = CertificateValidationContext.message(for: error, description: error.localizedFailureReason ?? error.localizedDescription)
+                        let alertController = UIAlertController(title: NSLocalizedString("Failed to Resign SideStore", comment: ""), message: message, preferredStyle: .alert)
+                        // Retrying here cannot change the rejected signing identity.
+                        if error.userInfo[CertificateValidationContext.purposeErrorKey] == nil {
+                            alertController.addAction(UIAlertAction(title: NSLocalizedString("Try Again", comment: ""), style: .default, handler: { (action) in
+                                refresh()
+                            }))
+                        }
                         alertController.addAction(UIAlertAction(title: NSLocalizedString("Resign Later", comment: ""), style: .cancel, handler: { (action) in
                             self.completionHandler?(.failure(error))
                         }))

--- a/AltStore/Core/Model/InstalledApp.swift
+++ b/AltStore/Core/Model/InstalledApp.swift
@@ -13,12 +13,6 @@ import SideSign
 @preconcurrency import UIKit
 import SemanticVersion
 
-public enum CertificateStatus: Equatable, Sendable {
-    case valid(isCrossSigned: Bool)
-    case revoked
-    case expired
-}
-
 extension InstalledApp
 {
     public static var freeAccountActiveAppsLimit: Int {

--- a/AltStore/My Apps/MyAppsViewController.swift
+++ b/AltStore/My Apps/MyAppsViewController.swift
@@ -2726,18 +2726,9 @@ extension MyAppsViewController {
         picker.onSelectCertificate = { [weak self] cert in
             guard let self = self else { return }
             
-            let binaryCert = CertificateManager.shared.getSigningCertificate(at: installedApp.fileURL)
-            if let binaryCert = binaryCert, cert.serialNumber == binaryCert.serialNumber {
-                let alert = UIAlertController(
-                    title: NSLocalizedString("Same Certificate", comment: ""),
-                    message: NSLocalizedString("The selected certificate is already being used for this app. Please use the Resign option instead.", comment: ""),
-                    preferredStyle: .alert
-                )
-                alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default))
-                self.present(alert, animated: true)
-            } else {
-                self.setCertificate(cert, for: installedApp)
-            }
+            // A matching binary signature does not imply the same effective signing identity.
+            // Honor the user's explicit selection so the next resign uses this app override.
+            self.setCertificate(cert, for: installedApp)
         }
         picker.present(from: self)
     }

--- a/AltStore/Settings/Error Log/ErrorLogViewController.swift
+++ b/AltStore/Settings/Error Log/ErrorLogViewController.swift
@@ -136,7 +136,8 @@ private extension ErrorLogViewController
             let errorDescription = [nsError.localizedDescription, nsError.localizedRecoverySuggestion].compactMap { $0 }.joined(separator: "\n\n")
             cell.errorDescriptionTextView.text = errorDescription
             cell.errorDescriptionTextView.maximumNumberOfLines = 5
-            cell.errorDescriptionTextView.isCollapsed = !self.expandedErrorIDs.contains(loggedError.objectID)
+            // Keep certificate recovery and the data-loss warning visible beyond the five-line preview.
+            cell.errorDescriptionTextView.isCollapsed = nsError.userInfo[CertificateValidationContext.purposeErrorKey] == nil && !self.expandedErrorIDs.contains(loggedError.objectID)
             cell.errorDescriptionTextView.moreButton.addTarget(self, action: #selector(ErrorLogViewController.toggleCollapsingCell(_:)), for: .primaryActionTriggered)
             
             cell.appIconImageView.image = nil

--- a/SideStore/Core/Certificates/CertificateStatus.swift
+++ b/SideStore/Core/Certificates/CertificateStatus.swift
@@ -1,0 +1,7 @@
+// Shared by certificate verification and its diagnostics.
+
+public enum CertificateStatus: Equatable, Sendable {
+    case valid(isCrossSigned: Bool)
+    case revoked
+    case expired
+}

--- a/SideStore/Core/Operations/Errors/CertificateValidationContext.swift
+++ b/SideStore/Core/Operations/Errors/CertificateValidationContext.swift
@@ -1,0 +1,114 @@
+//
+//  CertificateValidationContext.swift
+//  SideStore
+//
+
+import Foundation
+
+/// Describes the certificate actually checked, independently of the app's database record.
+public struct CertificateValidationContext: Equatable, Sendable {
+    static let purposeErrorKey = "SideStoreCertificateValidationPurpose"
+
+    /// Toasts and resign alerts otherwise display only the description/failure reason.
+    static func message(for error: NSError, description: String? = nil) -> String {
+        let description = description ?? error.localizedDescription
+        guard error.userInfo[purposeErrorKey] != nil, let recovery = error.localizedRecoverySuggestion else {
+            return description
+        }
+        return description + "\n\n" + recovery
+    }
+
+    public enum Purpose: String, Sendable {
+        case existingSignature
+        case defaultSigningIdentity
+        case appSpecificSigningIdentity
+    }
+
+    let purpose: Purpose
+    let checkedCertificateSerial: String
+    let installedAppSerial: String?
+    let activeCertificateSerial: String?
+    let overrideCertificateSerial: String?
+    let isPresentOnPortal: Bool
+
+    init(willResign: Bool, checkedCertificateSerial: String, installedAppSerial: String?,
+         activeCertificateSerial: String?, overrideCertificateSerial: String?,
+         portalCertificateSerials: Set<String>) {
+        self.purpose = !willResign ? .existingSignature :
+            (overrideCertificateSerial != nil ? .appSpecificSigningIdentity : .defaultSigningIdentity)
+        self.checkedCertificateSerial = checkedCertificateSerial
+        self.installedAppSerial = installedAppSerial
+        self.activeCertificateSerial = activeCertificateSerial
+        self.overrideCertificateSerial = overrideCertificateSerial
+        self.isPresentOnPortal = portalCertificateSerials.contains(checkedCertificateSerial)
+    }
+
+    /// Portal membership is diagnostic evidence only. Validation has already decided the status.
+    func error(for status: CertificateStatus, appName: String, customTeam: String?) -> OperationError? {
+        switch status {
+        case .valid:
+            return nil
+        case .revoked:
+            if let customTeam {
+                return .customCertificateRevoked(appName: appName, activeTeam: customTeam, context: self)
+            }
+            return .certificateRevoked(appName: appName, context: self)
+        case .expired:
+            if let customTeam {
+                return .customCertificateExpired(appName: appName, activeTeam: customTeam, context: self)
+            }
+            return .certificateExpired(appName: appName, context: self)
+        }
+    }
+
+    func failureReason(appName: String, expired: Bool) -> String {
+        let format: String
+        switch (purpose, expired) {
+        case (.defaultSigningIdentity, false):
+            format = NSLocalizedString("The default local signing certificate selected to sign “%@” has been revoked.", comment: "Certificate selected for a signing operation")
+        case (.defaultSigningIdentity, true):
+            format = NSLocalizedString("The default local signing certificate selected to sign “%@” has expired.", comment: "Certificate selected for a signing operation")
+        case (.appSpecificSigningIdentity, false):
+            format = NSLocalizedString("The app-specific signing certificate selected to sign “%@” has been revoked.", comment: "Certificate override selected for a signing operation")
+        case (.appSpecificSigningIdentity, true):
+            format = NSLocalizedString("The app-specific signing certificate selected to sign “%@” has expired.", comment: "Certificate override selected for a signing operation")
+        case (.existingSignature, false):
+            format = NSLocalizedString("The certificate in the existing signature of “%@” has been revoked.", comment: "Certificate checked in the target app bundle")
+        case (.existingSignature, true):
+            format = NSLocalizedString("The certificate in the existing signature of “%@” has expired.", comment: "Certificate checked in the target app bundle")
+        }
+        return String(format: format, appName)
+    }
+
+    static let dataWarning = NSLocalizedString("Deleting the app does not repair the selected signing identity and can erase its local data.", comment: "Certificate recovery data loss warning")
+
+    static let certificateManagement = NSLocalizedString("Open Settings → Advanced → Certificates. Signing requires a valid certificate with its private key; a certificate listed on the Developer Portal alone is not enough.", comment: "Local certificate management recovery")
+
+    static let existingSignatureRecovery = NSLocalizedString("Before using Resign, check Settings → Advanced → Certificates for a valid signing identity with its private key, and check this app's Change Certificate selection. Then re-sign the app in place. If reinstalling is needed, install over the existing app without deleting it first.", comment: "Recovery for a failed existing signature")
+
+    var recoverySuggestion: String {
+        let nextStep: String
+        switch purpose {
+        case .defaultSigningIdentity:
+            nextStep = Self.certificateManagement + " " + NSLocalizedString("Use Activate on a valid local certificate with its private key to change the default, then retry.", comment: "Default signing identity recovery")
+        case .appSpecificSigningIdentity:
+            nextStep = Self.certificateManagement + " " + NSLocalizedString("Use this app's Change Certificate menu to select a valid signing identity with its private key before retrying. Changing only the default may leave the app-specific selection in use.", comment: "App-specific signing identity recovery")
+        case .existingSignature:
+            nextStep = Self.existingSignatureRecovery
+        }
+        return Self.dataWarning + "\n\n" + nextStep
+    }
+
+    /// Keep identifiers in Error Details, not the main message. Never include certificate
+    /// subjects, account information, device identifiers, private keys, or passwords here.
+    var diagnosticDetails: String {
+        """
+        certificateValidationPurpose: \(purpose.rawValue)
+        checkedCertificateSerial: \(checkedCertificateSerial)
+        installedAppSerial: \(installedAppSerial ?? "nil")
+        activeCertificateSerial: \(activeCertificateSerial ?? "nil")
+        overrideCertificateSerial: \(overrideCertificateSerial ?? "nil")
+        checkedCertificatePresentOnPortal: \(isPresentOnPortal)
+        """
+    }
+}

--- a/SideStore/Core/Operations/Errors/OperationError.swift
+++ b/SideStore/Core/Operations/Errors/OperationError.swift
@@ -18,10 +18,10 @@ public enum OperationError: LocalizedError, CustomNSError, Sendable, Equatable {
     case unknownResult
 
     case cacheClearError(errors: [String])
-    case certificateExpired(appName: String)
-    case certificateRevoked(appName: String)
-    case customCertificateExpired(appName: String, activeTeam: String)
-    case customCertificateRevoked(appName: String, activeTeam: String)
+    case certificateExpired(appName: String, context: CertificateValidationContext? = nil)
+    case certificateRevoked(appName: String, context: CertificateValidationContext? = nil)
+    case customCertificateExpired(appName: String, activeTeam: String, context: CertificateValidationContext? = nil)
+    case customCertificateRevoked(appName: String, activeTeam: String, context: CertificateValidationContext? = nil)
     case forbidden(failureReason: String, file: String = #fileID, line: UInt = #line)
     case invalidApp(reason: String)
     case invalidPairingFile(reason: String)
@@ -65,14 +65,14 @@ public enum OperationError: LocalizedError, CustomNSError, Sendable, Equatable {
 
         case .cacheClearError(let errors):
             return "An error occurred while clearing the cache: \(errors.joined(separator: "\n"))"
-        case .certificateExpired(let appName):
-            return "The signing certificate used to install “\(appName)” has expired. Please re-sign or reinstall the app."
-        case .certificateRevoked(let appName):
-            return "The signing certificate used to install “\(appName)” was revoked on the Apple Developer portal. Please re-sign or reinstall the app."
-        case .customCertificateExpired(_, let activeTeam):
-            return "Your active custom/third-party signing certificate (Team: \(activeTeam)) has expired.\n\nIf you did not intend to use a custom certificate, please reset it in Settings -> Advanced -> Certificates."
-        case .customCertificateRevoked(_, let activeTeam):
-            return "Your active custom/third-party signing certificate (Team: \(activeTeam)) was revoked on the Developer Portal.\n\nIf you did not intend to use a custom certificate, please reset it in Settings -> Advanced -> Certificates."
+        case .certificateExpired(let appName, let context):
+            return context?.failureReason(appName: appName, expired: true) ?? String(format: NSLocalizedString("The certificate in the existing signature of “%@” has expired.", comment: "Existing app signature failure"), appName)
+        case .certificateRevoked(let appName, let context):
+            return context?.failureReason(appName: appName, expired: false) ?? String(format: NSLocalizedString("The certificate in the existing signature of “%@” has been revoked.", comment: "Existing app signature failure"), appName)
+        case .customCertificateExpired(let appName, _, let context):
+            return context?.failureReason(appName: appName, expired: true) ?? NSLocalizedString("The custom signing certificate has expired.", comment: "Custom certificate failure")
+        case .customCertificateRevoked(let appName, _, let context):
+            return context?.failureReason(appName: appName, expired: false) ?? NSLocalizedString("The custom signing certificate has been revoked.", comment: "Custom certificate failure")
         case .forbidden(let reason, _, _):
             return reason
         case .invalidApp(let reason):
@@ -123,11 +123,66 @@ public enum OperationError: LocalizedError, CustomNSError, Sendable, Equatable {
     }
 
     public var failureReason: String? {
-        return NSLocalizedString(self.rawDescription, comment: "")
+        // Certificate messages use static format keys before substituting the app name.
+        switch self {
+        case .certificateExpired, .certificateRevoked, .customCertificateExpired, .customCertificateRevoked:
+            return self.rawDescription
+        default:
+            return NSLocalizedString(self.rawDescription, comment: "")
+        }
+    }
+
+    private var certificateContext: CertificateValidationContext? {
+        switch self {
+        case .certificateExpired(_, let context), .certificateRevoked(_, let context),
+             .customCertificateExpired(_, _, let context), .customCertificateRevoked(_, _, let context):
+            return context
+        default:
+            return nil
+        }
+    }
+
+    public var errorUserInfo: [String: Any] {
+        // CustomNSError needs explicit localized values for the certificate error to survive
+        // NSError bridging and LoggedError persistence. Leave unrelated error cases unchanged.
+        switch self {
+        case .certificateExpired, .certificateRevoked, .customCertificateExpired, .customCertificateRevoked:
+            break
+        default:
+            return [:]
+        }
+        var info: [String: Any] = [:]
+        info[NSLocalizedDescriptionKey] = errorDescription
+        info[NSLocalizedFailureReasonErrorKey] = failureReason
+        info[NSLocalizedRecoverySuggestionErrorKey] = recoverySuggestion
+        if let context = certificateContext {
+            info[CertificateValidationContext.purposeErrorKey] = context.purpose.rawValue
+            var details = context.diagnosticDetails
+            switch self {
+            case .certificateExpired, .customCertificateExpired:
+                details += "\ncertificateValidationStatus: expired"
+            case .certificateRevoked, .customCertificateRevoked:
+                details += "\ncertificateValidationStatus: revoked"
+            default:
+                break
+            }
+            switch self {
+            case .customCertificateExpired(_, let team, _), .customCertificateRevoked(_, let team, _):
+                details += "\ncheckedCertificateCustomTeam: \(team)"
+            default:
+                break
+            }
+            info[NSDebugDescriptionErrorKey] = details
+        }
+        return info
     }
 
     public var recoverySuggestion: String? {
         switch self {
+        case .certificateExpired(_, let context), .certificateRevoked(_, let context):
+            return context?.recoverySuggestion ?? CertificateValidationContext.dataWarning + "\n\n" + CertificateValidationContext.existingSignatureRecovery
+        case .customCertificateExpired(_, _, let context), .customCertificateRevoked(_, _, let context):
+            return context?.recoverySuggestion ?? CertificateValidationContext.dataWarning + "\n\n" + CertificateValidationContext.certificateManagement
         case .invalidPairingFile:
             return NSLocalizedString("Import a valid mobiledevicepairing file.", comment: "")
         case .invalidVPN, .noVPN:

--- a/SideStore/Core/Operations/PipelineOperations/VerifyCertificateOperation.swift
+++ b/SideStore/Core/Operations/PipelineOperations/VerifyCertificateOperation.swift
@@ -67,7 +67,7 @@ final class VerifyCertificateOperation: BasePipelineOperation<InstallAppOperatio
                 let result = await validateCertificate(binaryCert, portalCertificateSerials: portalCertificateSerials, signingCertificateSerial: signingCertificateSerial)
                 finalStatus = result
                 self.context.targetCertStatus = result
-                try processValidationResult(result, description: "Target bundle binary certificate", appName: appName, team: team)
+                try processValidationResult(result, certificate: binaryCert, appName: appName, installedAppSerial: installedAppSerial, portalCertificateSerials: portalCertificateSerials, team: team)
                 
             } else {
                 // resigning branch
@@ -81,7 +81,7 @@ final class VerifyCertificateOperation: BasePipelineOperation<InstallAppOperatio
                 let result = await validateCertificate(target.x509, portalCertificateSerials: portalCertificateSerials, signingCertificateSerial: signingCertificateSerial)
                 finalStatus = result
                 self.context.targetCertStatus = result
-                try processValidationResult(result, description: "Target signing certificate", appName: appName, team: team)
+                try processValidationResult(result, certificate: target.x509, appName: appName, installedAppSerial: installedAppSerial, portalCertificateSerials: portalCertificateSerials, team: team)
             }
             
             await self.persistStateIfChanged(bundleID: bundleID, status: finalStatus, initialStatus: initialStatus)
@@ -164,50 +164,32 @@ final class VerifyCertificateOperation: BasePipelineOperation<InstallAppOperatio
         }
     }
     
-    private func processValidationResult(_ result: CertificateStatus, description: String, appName: String, team: ALTTeam) throws {
-        // Check if there is a team ID mismatch with the active certificate
-        var activeTeamID: String? = nil
-        var isCustomCertActive = false
-        
-        if let activeCert = CertificateManager.shared.activeCertificate?.certificate,
-           let data = activeCert.data {
-                let details = parseCertificate(derData: data)
-                let belongsToAuthenticatedTeam = details.subject.contains(team.identifier) || details.issuer.contains(team.identifier)
-                if !belongsToAuthenticatedTeam {
-                    isCustomCertActive = true
-                    // Try to extract the team ID of the active cert from its Subject
-                    // (It is friendly labeled as "Organizational Unit" in the parsed DN string)
-                    if let ouPart = details.subject.components(separatedBy: ", ").first(where: { $0.hasPrefix("Organizational Unit=") }) {
-                        activeTeamID = ouPart.replacingOccurrences(of: "Organizational Unit=", with: "")
-                    }
-                }
+    private func processValidationResult(_ result: CertificateStatus, certificate: ALTX509Certificate,
+                                         appName: String, installedAppSerial: String?,
+                                         portalCertificateSerials: Set<String>, team: ALTTeam) throws {
+        let validationContext = CertificateValidationContext(
+            willResign: self.willResign,
+            checkedCertificateSerial: certificate.serialNumber,
+            installedAppSerial: installedAppSerial,
+            activeCertificateSerial: self.context.activeSigningCertificate?.serialNumber,
+            overrideCertificateSerial: self.context.overrideSigningCertificate?.serialNumber,
+            portalCertificateSerials: portalCertificateSerials
+        )
+
+        // Classify the certificate we actually checked, not a possibly unrelated global identity.
+        var customTeam: String?
+        if let data = certificate.data {
+            let details = parseCertificate(derData: data)
+            let belongsToAuthenticatedTeam = details.subject.contains(team.identifier) || details.issuer.contains(team.identifier)
+            if !belongsToAuthenticatedTeam {
+                let ouPart = details.subject.components(separatedBy: ", ").first { $0.hasPrefix("Organizational Unit=") }
+                customTeam = ouPart?.replacingOccurrences(of: "Organizational Unit=", with: "") ?? "Unknown Custom Team"
             }
-        
-        switch result {
-        case .valid(let isCrossSigned):
-            if isCrossSigned {
-                debugLog("[VerifyCertificateOperation] \(description) is VALID (cross-signed)")
-            } else {
-                debugLog("[VerifyCertificateOperation] \(description) is VALID")
-            }
-        case .revoked:
-            debugLog("[VerifyCertificateOperation] \(description) is REVOKED")
-            if isCustomCertActive {
-                throw OperationError.customCertificateRevoked(
-                    appName: appName,
-                    activeTeam: activeTeamID ?? "Unknown Custom Team"
-                )
-            }
-            throw OperationError.certificateRevoked(appName: appName)
-        case .expired:
-            debugLog("[VerifyCertificateOperation] \(description) is EXPIRED")
-            if isCustomCertActive {
-                throw OperationError.customCertificateExpired(
-                    appName: appName,
-                    activeTeam: activeTeamID ?? "Unknown Custom Team"
-                )
-            }
-            throw OperationError.certificateExpired(appName: appName)
+        }
+
+        debugLog("[VerifyCertificateOperation] \(validationContext.purpose.rawValue): \(result)")
+        if let error = validationContext.error(for: result, appName: appName, customTeam: customTeam) {
+            throw error
         }
     }
 }

--- a/SideStore/Tests/UnitTests/certificates/CertificateDiagnosticsTests.swift
+++ b/SideStore/Tests/UnitTests/certificates/CertificateDiagnosticsTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import XCTest
+
+final class CertificateDiagnosticsTests: XCTestCase {
+    private let appName = "Example App"
+
+    private func context(willResign: Bool = true, checked: String = "CERT_A",
+                         installed: String? = nil, active: String? = "CERT_A",
+                         override: String? = nil, portal: Set<String> = ["CERT_B"]) -> CertificateValidationContext {
+        CertificateValidationContext(willResign: willResign, checkedCertificateSerial: checked,
+                                     installedAppSerial: installed, activeCertificateSerial: active,
+                                     overrideCertificateSerial: override, portalCertificateSerials: portal)
+    }
+
+    func testFreshInstallIdentifiesDefaultForRevokedAndExpiredCertificates() throws {
+        for status: CertificateStatus in [.revoked, .expired] {
+            let error = try XCTUnwrap(context().error(for: status, appName: appName, customTeam: nil))
+            XCTAssertTrue(error.localizedDescription.contains("default local signing certificate selected to sign"))
+            XCTAssertFalse(error.localizedDescription.contains("used to install"))
+            XCTAssertFalse(error.localizedDescription.contains("existing signature"))
+            XCTAssertFalse(error.localizedDescription.contains("CERT_A"))
+            let details = try XCTUnwrap((error as NSError).userInfo[NSDebugDescriptionErrorKey] as? String)
+            XCTAssertTrue(details.contains("checkedCertificateSerial: CERT_A"))
+            XCTAssertTrue(details.contains("installedAppSerial: nil"))
+            XCTAssertTrue(details.contains("checkedCertificatePresentOnPortal: false"))
+            XCTAssertTrue(try XCTUnwrap(error.recoverySuggestion).contains("Use Activate"))
+        }
+    }
+
+    func testOverrideIsReportedEvenWithValidDefault() throws {
+        for status: CertificateStatus in [.revoked, .expired] {
+            let diagnostic = context(installed: "CERT_B", active: "CERT_B", override: "CERT_A")
+            let error = try XCTUnwrap(diagnostic.error(for: status, appName: appName, customTeam: nil))
+            XCTAssertEqual(diagnostic.purpose, .appSpecificSigningIdentity)
+            XCTAssertTrue(error.localizedDescription.contains("app-specific signing certificate selected to sign"))
+            XCTAssertFalse(error.localizedDescription.contains("default local"))
+            let recovery = try XCTUnwrap(error.recoverySuggestion)
+            XCTAssertTrue(recovery.contains("Change Certificate"))
+            XCTAssertTrue(recovery.contains("Changing only the default may leave the app-specific selection in use"))
+            XCTAssertTrue(diagnostic.diagnosticDetails.contains("activeCertificateSerial: CERT_B"))
+        }
+        // Presence of an override, even if it matches the default, determines its role.
+        XCTAssertEqual(context(override: "CERT_A").purpose, .appSpecificSigningIdentity)
+    }
+
+    func testVerificationDescribesCheckedBinaryRegardlessOfSigningSelection() throws {
+        for status: CertificateStatus in [.revoked, .expired] {
+            let diagnostic = context(willResign: false, installed: "CERT_A", active: "CERT_B", override: "CERT_B")
+            let error = try XCTUnwrap(diagnostic.error(for: status, appName: appName, customTeam: nil))
+            XCTAssertEqual(diagnostic.purpose, .existingSignature)
+            XCTAssertTrue(error.localizedDescription.contains("existing signature"))
+            XCTAssertFalse(error.localizedDescription.contains("selected to sign"))
+            XCTAssertTrue(try XCTUnwrap(error.recoverySuggestion).contains("Before using Resign, check"))
+            XCTAssertTrue(try XCTUnwrap(error.recoverySuggestion).contains("install over the existing app without deleting it first"))
+        }
+    }
+
+    func testFailureStatusAndCodesRemainDistinct() throws {
+        for diagnostic in [context(), context(override: "CERT_A"), context(willResign: false)] {
+            for customTeam: String? in [nil, "CUSTOM_TEAM"] {
+                let revoked = try XCTUnwrap(diagnostic.error(for: .revoked, appName: appName, customTeam: customTeam))
+                let expired = try XCTUnwrap(diagnostic.error(for: .expired, appName: appName, customTeam: customTeam))
+                XCTAssertTrue(revoked.localizedDescription.contains("has been revoked"))
+                XCTAssertTrue(expired.localizedDescription.contains("has expired"))
+                XCTAssertEqual((revoked as NSError).code, customTeam == nil ? 2 : 4)
+                XCTAssertEqual((expired as NSError).code, customTeam == nil ? 1 : 3)
+                XCTAssertEqual((revoked as NSError).domain, OperationError.errorDomain)
+                XCTAssertTrue(((revoked as NSError).userInfo[NSDebugDescriptionErrorKey] as? String)?.contains("certificateValidationStatus: revoked") == true)
+                XCTAssertTrue(((expired as NSError).userInfo[NSDebugDescriptionErrorKey] as? String)?.contains("certificateValidationStatus: expired") == true)
+                if customTeam != nil {
+                    let details = try XCTUnwrap((revoked as NSError).userInfo[NSDebugDescriptionErrorKey] as? String)
+                    XCTAssertTrue(details.contains("checkedCertificateCustomTeam: CUSTOM_TEAM"))
+                }
+            }
+        }
+        // Compiler-derived codes captured from develop before changing associated values.
+        XCTAssertEqual((OperationError.noInstalledApps as NSError).code, 26)
+        XCTAssertEqual((OperationError.invalidParameters("test") as NSError).code, 8)
+        XCTAssertEqual((OperationError.unknownUDID(reason: "test") as NSError).code, 25)
+    }
+
+    func testValidAndCrossTeamCertificatesDoNotBecomeDiagnosticFailures() {
+        for diagnostic in [context(), context(override: "CERT_A"), context(willResign: false), context(portal: ["CERT_A"])] {
+            for isCrossSigned in [false, true] {
+                for customTeam: String? in [nil, "CUSTOM_TEAM"] {
+                    XCTAssertNil(diagnostic.error(for: .valid(isCrossSigned: isCrossSigned), appName: appName, customTeam: customTeam))
+                }
+            }
+        }
+    }
+
+    func testRecoveryRequiresChangingInvalidIdentityAndWarnsAboutDataLoss() throws {
+        for diagnostic in [context(), context(override: "CERT_A"), context(willResign: false)] {
+            for status: CertificateStatus in [.revoked, .expired] {
+                let error = try XCTUnwrap(diagnostic.error(for: status, appName: appName, customTeam: nil))
+                let recovery = try XCTUnwrap(error.recoverySuggestion)
+                XCTAssertTrue(recovery.hasPrefix("Deleting the app does not repair the selected signing identity and can erase its local data."))
+                XCTAssertTrue(recovery.contains("Settings → Advanced → Certificates"))
+                XCTAssertTrue(recovery.contains("private key"))
+                XCTAssertFalse(recovery.contains("Please re-sign or reinstall"))
+                XCTAssertFalse(recovery.contains("sign out"))
+                XCTAssertFalse(recovery.contains("delete the app"))
+                if diagnostic.purpose != .existingSignature {
+                    XCTAssertTrue(recovery.contains("Developer Portal alone is not enough"))
+                    XCTAssertFalse(recovery.contains("Resign"))
+                }
+            }
+        }
+    }
+
+    func testNSErrorRoundTripPreservesRecoveryAndDetailsForErrorLogAndAlerts() throws {
+        let error = try XCTUnwrap(context().error(for: .revoked, appName: appName, customTeam: nil)) as NSError
+        // AppManager's serialization sanitizer retains only NSSecureCoding userInfo values.
+        XCTAssertTrue(error.userInfo.values.allSatisfy { $0 is NSSecureCoding })
+        // LoggedError persists domain, code and userInfo, then reconstructs NSError.
+        let archived = try NSKeyedArchiver.archivedData(withRootObject: error, requiringSecureCoding: true)
+        let restored = try XCTUnwrap(NSKeyedUnarchiver.unarchivedObject(ofClass: NSError.self, from: archived))
+        let logged = NSError(domain: restored.domain, code: restored.code, userInfo: restored.userInfo)
+        XCTAssertEqual(logged.localizedDescription, error.localizedDescription)
+        XCTAssertEqual(logged.localizedRecoverySuggestion, error.localizedRecoverySuggestion)
+        XCTAssertEqual(logged.userInfo[CertificateValidationContext.purposeErrorKey] as? String, "defaultSigningIdentity")
+        XCTAssertEqual(logged.userInfo[NSDebugDescriptionErrorKey] as? String, error.userInfo[NSDebugDescriptionErrorKey] as? String)
+        let logText = [logged.localizedDescription, logged.localizedRecoverySuggestion].compactMap { $0 }.joined(separator: "\n\n")
+        XCTAssertEqual(CertificateValidationContext.message(for: logged), logText)
+        XCTAssertEqual(CertificateValidationContext.message(for: logged, description: logged.localizedFailureReason), logText)
+        XCTAssertTrue(logText.contains("can erase its local data"))
+        XCTAssertFalse(logText.contains("CERT_A"))
+    }
+
+    func testWrappedErrorPreservesGuidance() throws {
+        let error = try XCTUnwrap(context(override: "CERT_A").error(for: .expired, appName: appName, customTeam: nil)) as NSError
+        var info = error.userInfo
+        info[NSLocalizedFailureErrorKey] = "Unable to refresh App"
+        let wrapped = ALTWrappedError(error: error, userInfo: info)
+        let message = CertificateValidationContext.message(for: wrapped)
+        XCTAssertTrue(message.contains("app-specific signing certificate"))
+        XCTAssertTrue(message.contains("can erase its local data"))
+        XCTAssertTrue(message.contains("Change Certificate"))
+    }
+
+    func testUnrelatedErrorPresentationIsUnchanged() {
+        XCTAssertTrue((OperationError.invalidParameters("test") as NSError).userInfo.isEmpty)
+        let error = NSError(domain: "Other", code: 1, userInfo: [NSLocalizedDescriptionKey: "Other failure", NSLocalizedRecoverySuggestionErrorKey: "Other recovery"])
+        XCTAssertEqual(CertificateValidationContext.message(for: error), "Other failure")
+    }
+}

--- a/SideStore/Utils/dignostics/errors/ErrorProcessing.swift
+++ b/SideStore/Utils/dignostics/errors/ErrorProcessing.swift
@@ -42,7 +42,7 @@ class ErrorProcessing {
                 return NSLocalizedString("Keychain security error.", comment: "")
             }
         }
-        return error.localizedDescription
+        return CertificateValidationContext.message(for: error)
     }
 
     private func processError(_ error: NSError, ignoreTitle: Bool = false, getMoreErrors: (_ error: NSError)->String) -> String{

--- a/SideStore/Views/Settings/Advanced/DeveloperServices/Certificates/CertificatesPortalListView.swift
+++ b/SideStore/Views/Settings/Advanced/DeveloperServices/Certificates/CertificatesPortalListView.swift
@@ -31,7 +31,7 @@ struct CertificatesPortalListView: View {
 
     var body: some View {
         List {
-            Section(header: Text("Certificates (\(viewModel.certificates.count))"), footer: Text("Certificates registered on your Apple Developer team. Revoking invalidates the certificate on Apple's portal.")) {
+            Section(header: Text("Certificates (\(viewModel.certificates.count))"), footer: Text("Certificates registered on your Apple Developer team. Listed certificates are not necessarily selected for local signing or available with a private key. Manage local signing in Settings → Advanced → Certificates. Revoking invalidates the certificate on Apple's portal.")) {
                 if filteredCertificates.isEmpty {
                     if viewModel.isLoading {
                         HStack {
@@ -130,7 +130,7 @@ private struct CertificatePortalRow: View {
                         .foregroundColor(.red)
                         .cornerRadius(6)
                 } else {
-                    Text("Active")
+                    Text("Not Expired")
                         .font(.caption2)
                         .fontWeight(.medium)
                         .padding(.horizontal, 6)


### PR DESCRIPTION
### Description of Changes

SideStore told me to re-sign or reinstall an app, but both kept using the same revoked local signing certificate. The portal showed a different certificate as “Active,” making the recovery guidance confusing.

This PR makes SideStore explain which certificate failed and how to address it. LiveContainer happened to be the target app; the failure occurred in SideStore before signing or installation.

<details>
<summary>Incident details and anonymized evidence</summary>

After reinstalling SideStore through iloader on another PC and replacing the pairing file, SideStore remained signed in. Its running binary used a valid certificate, B, while its local signing selection remained the old, revoked certificate, A.

1. Re-signing LiveContainer failed.
2. I tried Change Certificate. The portal showed one certificate labelled “Active,” and the dialog directed me back to Resign.
3. I uninstalled LiveContainer to reinstall it, losing its local data. Installation then failed with the same guidance.

Signing out of the Apple ID in SideStore and signing back in eventually resolved my incident. Pairing and device communication were working.

Selected diagnostic fields from the failed installation, with identifiers replaced:

```text
installedAppSerial: nil
overrideCertSerial: nil
activeCertSerial: CERT_A
targetSigningCertSerial: CERT_A
portalCertificateSerials: [CERT_B]
willResign: true

OCSP confirmed CERT_A revoked.
The target app was absent from SideStore’s database.
The operation failed before signing or installation.
```

SideStore nevertheless reported:

> The signing certificate used to install “com.kdt.livecontainer” was revoked on the Apple Developer portal. Please re-sign or reinstall the app.

Screenshots from the reported build, with sensitive details redacted:

<img src="https://raw.githubusercontent.com/glebosotov/SideStore/34f2337e63703a08260edbdb2bd0a5a94fcf96b4/error-log-redacted.png" alt="Misleading certificate recovery errors" width="320">

<img src="https://raw.githubusercontent.com/glebosotov/SideStore/34f2337e63703a08260edbdb2bd0a5a94fcf96b4/portal-certificate-redacted.png" alt="Portal certificate labelled Active" width="320">

</details>

### Rationale behind Changes

Revoked and expired errors now distinguish the selected signing identity from an existing app’s signature. Guidance points to certificate management and warns that deleting the app won’t repair the identity and can erase local data.

The change also clarifies the portal’s “Active” label and removes the misleading “Same Certificate → Resign” loop. Certificate validation remains unchanged; automatic recovery is outside this PR.

### Suggested Testing Steps

```sh
xcodebuild test -project AltStore.xcodeproj \
  -scheme CertificateDiagnosticsTests -destination 'platform=macOS'
```

All 9 native tests and the unsigned iOS Release build passed with Xcode 26.2. Existing develop error codes are preserved.

Device signing/install behavior, live OCSP, and UI layout still need runtime testing.

### Did you use AI to help find, test, or implement this issue or feature?

Yes. OpenAI Codex helped investigate, implement, test, and write this description.
